### PR TITLE
Cake CoreCLR fix

### DIFF
--- a/src/Cake.GitVersioning/Cake.GitVersioning.csproj
+++ b/src/Cake.GitVersioning/Cake.GitVersioning.csproj
@@ -13,9 +13,10 @@
     <PackageIcon>cake-contrib-medium.png</PackageIcon>
     <PackageProjectUrl>http://github.com/aarnott/Nerdbank.GitVersioning</PackageProjectUrl>
     <SignAssembly>false</SignAssembly>
-    <!-- We include the whole OutputPath in this tools package. -->
-    <IncludeBuildOutput>false</IncludeBuildOutput>
+
     <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);PackBuildOutputs</TargetsForTfmSpecificContentInPackage>
+    <LibGit2SharpNativeBinaries>$(NuGetPackageRoot)libgit2sharp.nativebinaries\2.0.298\</LibGit2SharpNativeBinaries>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
   <!-- This is a tools package and should express no dependencies. -->
@@ -36,6 +37,17 @@
 
   <ItemGroup>
     <None Include="cake-contrib-medium.png" Pack="true" PackagePath="" />
+
+    <!-- Adapt Nerdbank.GitVersioning nuspec file to csproj -->
+    <None Include="$(LibGit2SharpNativeBinaries)runtimes\**\*.*" Pack="true" PackagePath="lib\netstandard2.0\lib\" LinkBase="lib" />
+
+    <!-- Additional copies to work around DllNotFoundException on Mono (https://github.com/AArnott/Nerdbank.GitVersioning/issues/222) -->
+    <None Include="$(LibGit2SharpNativeBinaries)runtimes\osx\native\libgit2-ef5a385.dylib" Pack="true" PackagePath="lib\netstandard2.0\lib\osx\libgit2-ef5a385.dylib" LinkBase="lib\osx" />
+    <None Include="$(LibGit2SharpNativeBinaries)runtimes\linux-x64\native\libgit2-ef5a385.so" Pack="true" PackagePath="lib\netstandard2.0\lib\linux\x86_64\libgit2-ef5a385.so" LinkBase="lib\linux\x86_64" />
+
+    <!-- Additional copies to work with our own ps1 scripts (https://github.com/AArnott/Nerdbank.GitVersioning/issues/248) -->
+    <None Include="$(LibGit2SharpNativeBinaries)runtimes\win-x64\native\git2-ef5a385.dll" Pack="true" PackagePath="lib\netstandard2.0\lib\win32\x64\git2-ef5a385.dll" LinkBase="lib\win32\x64" />
+    <None Include="$(LibGit2SharpNativeBinaries)runtimes\win-x86\native\git2-ef5a385.dll" Pack="true" PackagePath="lib\netstandard2.0\lib\win32\x86\git2-ef5a385.dll" LinkBase="lib\win32\x86" />
   </ItemGroup>
 
   <ItemGroup>
@@ -44,7 +56,19 @@
 
   <Target Name="PackBuildOutputs" DependsOnTargets="SatelliteDllsProjectOutputGroup;DebugSymbolsProjectOutputGroup">
     <ItemGroup>
-      <TfmSpecificPackageFile Include="$(OutputPath)\**\*" Exclude="$(OutputPath)\**\*.xml;$(OutputPath)\**\*.pdb;$(OutputPath)\**\Cake.Core.dll">
+      <TfmSpecificPackageFile
+        Include="
+                  $(OutputPath)LibGit2Sharp.dll*;
+                  $(OutputPath)Nerdbank.GitVersioning.*dll;
+                  $(OutputPath)Newtonsoft.Json.dll;
+                  $(OutputPath)Validation.dll;
+                  "
+
+        Exclude="
+                  $(OutputPath)Microsoft.*.dll
+                  $(OutputPath)System.*.dll
+                  "
+        >
         <PackagePath>lib\$(TargetFramework)\</PackagePath>
       </TfmSpecificPackageFile>
     </ItemGroup>

--- a/src/Cake.GitVersioning/Cake.GitVersioning.csproj
+++ b/src/Cake.GitVersioning/Cake.GitVersioning.csproj
@@ -15,7 +15,7 @@
     <SignAssembly>false</SignAssembly>
 
     <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);PackBuildOutputs</TargetsForTfmSpecificContentInPackage>
-    <LibGit2SharpNativeBinaries>$(NuGetPackageRoot)libgit2sharp.nativebinaries\2.0.298\</LibGit2SharpNativeBinaries>
+    <LibGit2SharpNativeBinaries>$(NuGetPackageRoot)libgit2sharp.nativebinaries\$(LibGit2SharpNativeVersion)\</LibGit2SharpNativeBinaries>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 

--- a/src/Cake.GitVersioning/Cake.GitVersioning.csproj
+++ b/src/Cake.GitVersioning/Cake.GitVersioning.csproj
@@ -69,11 +69,6 @@
         >
         <PackagePath>lib\$(TargetFramework)</PackagePath>
       </TfmSpecificPackageFile>
-
-      <!-- Package up the libgit2 native binaries -->
-      <TfmSpecificPackageFile Include="@(ContentWithTargetPath)" Condition=" '%(ContentWithTargetPath.CopyToOutputDirectory)' == 'PreserveNewest' ">
-        <PackagePath>lib\$(TargetFramework)%(ContentWithTargetPath.TargetPath)</PackagePath>
-      </TfmSpecificPackageFile>
     </ItemGroup>
   </Target>
 </Project>

--- a/src/Cake.GitVersioning/Cake.GitVersioning.csproj
+++ b/src/Cake.GitVersioning/Cake.GitVersioning.csproj
@@ -38,16 +38,14 @@
   <ItemGroup>
     <None Include="cake-contrib-medium.png" Pack="true" PackagePath="" />
 
-    <!-- Adapt Nerdbank.GitVersioning nuspec file to csproj -->
+    <!-- Include native binaries -->
     <None Include="$(LibGit2SharpNativeBinaries)runtimes\**\*.*" Pack="true" PackagePath="lib\netstandard2.0\lib\" LinkBase="lib" />
 
     <!-- Additional copies to work around DllNotFoundException on Mono (https://github.com/AArnott/Nerdbank.GitVersioning/issues/222) -->
-    <None Include="$(LibGit2SharpNativeBinaries)runtimes\osx\native\libgit2-ef5a385.dylib" Pack="true" PackagePath="lib\netstandard2.0\lib\osx\libgit2-ef5a385.dylib" LinkBase="lib\osx" />
-    <None Include="$(LibGit2SharpNativeBinaries)runtimes\linux-x64\native\libgit2-ef5a385.so" Pack="true" PackagePath="lib\netstandard2.0\lib\linux\x86_64\libgit2-ef5a385.so" LinkBase="lib\linux\x86_64" />
-
-    <!-- Additional copies to work with our own ps1 scripts (https://github.com/AArnott/Nerdbank.GitVersioning/issues/248) -->
-    <None Include="$(LibGit2SharpNativeBinaries)runtimes\win-x64\native\git2-ef5a385.dll" Pack="true" PackagePath="lib\netstandard2.0\lib\win32\x64\git2-ef5a385.dll" LinkBase="lib\win32\x64" />
-    <None Include="$(LibGit2SharpNativeBinaries)runtimes\win-x86\native\git2-ef5a385.dll" Pack="true" PackagePath="lib\netstandard2.0\lib\win32\x86\git2-ef5a385.dll" LinkBase="lib\win32\x86" />
+    <None Include="$(LibGit2SharpNativeBinaries)runtimes\osx\native\*.dylib" Pack="true" PackagePath="lib\netstandard2.0\lib\osx\" LinkBase="lib\osx" />
+    <None Include="$(LibGit2SharpNativeBinaries)runtimes\linux-x64\native\*.so" Pack="true" PackagePath="lib\netstandard2.0\lib\linux\x86_64\" LinkBase="lib\linux\x86_64" />
+    <None Include="$(LibGit2SharpNativeBinaries)runtimes\win-x64\native\*.dll" Pack="true" PackagePath="lib\netstandard2.0\lib\win32\x64\" LinkBase="lib\win32\x64" />
+    <None Include="$(LibGit2SharpNativeBinaries)runtimes\win-x86\native\*.dll" Pack="true" PackagePath="lib\netstandard2.0\lib\win32\x86\" LinkBase="lib\win32\x86" />
   </ItemGroup>
 
   <ItemGroup>
@@ -69,7 +67,12 @@
                   $(OutputPath)System.*.dll
                   "
         >
-        <PackagePath>lib\$(TargetFramework)\</PackagePath>
+        <PackagePath>lib\$(TargetFramework)</PackagePath>
+      </TfmSpecificPackageFile>
+
+      <!-- Package up the libgit2 native binaries -->
+      <TfmSpecificPackageFile Include="@(ContentWithTargetPath)" Condition=" '%(ContentWithTargetPath.CopyToOutputDirectory)' == 'PreserveNewest' ">
+        <PackagePath>lib\$(TargetFramework)%(ContentWithTargetPath.TargetPath)</PackagePath>
       </TfmSpecificPackageFile>
     </ItemGroup>
   </Target>

--- a/src/Cake.GitVersioning/GitVersioningAliases.cs
+++ b/src/Cake.GitVersioning/GitVersioningAliases.cs
@@ -6,6 +6,11 @@ using Nerdbank.GitVersioning;
 
 namespace Cake.GitVersioning
 {
+    using System;
+    using System.Linq;
+
+    using Validation;
+
     /// <summary>
     /// Contains functionality for using Nerdbank.GitVersioning.
     /// </summary>
@@ -30,7 +35,35 @@ namespace Cake.GitVersioning
         {
             var fullProjectDirectory = (new DirectoryInfo(projectDirectory)).FullName;
 
-            GitExtensions.HelpFindLibGit2NativeBinaries(Path.GetDirectoryName(Assembly.GetAssembly(typeof(GitVersioningAliases)).Location));
+            string directoryName = Path.GetDirectoryName(Assembly.GetAssembly(typeof(GitVersioningAliases)).Location);
+
+            if (string.IsNullOrWhiteSpace(directoryName))
+            {
+                throw new InvalidOperationException("Could not locate the Cake.GitVersioning library");
+            }
+
+            // Even after adding the folder containing the native libgit2 DLL to the PATH, DllNotFoundException is still thrown
+            // Workaround this by copying the contents of the found folder to the current directory
+            GitExtensions.HelpFindLibGit2NativeBinaries(directoryName, out var attemptedDirectory);
+
+            // The HelpFindLibGit2NativeBinaries method throws if the directory does not exist
+            var directoryInfo = new DirectoryInfo(attemptedDirectory);
+
+            // There should only be a single file in the directory, but we do not know its extension
+            // So, we will just get a list of all files rather than trying to determine the correct name and extension
+            // If there are other files there for some reason, it should not matter as long as we don't overwrite anything in the current directory
+            var fileInfos = directoryInfo.GetFiles();
+
+            foreach (var fileInfo in fileInfos)
+            {
+                // Copy the file to the Cake.GitVersioning DLL directory, without overwriting anything
+                string destFileName = Path.Combine(directoryName, fileInfo.Name);
+
+                if (!File.Exists(destFileName))
+                {
+                    File.Copy(fileInfo.FullName, destFileName);
+                }
+            }
 
             return VersionOracle.Create(fullProjectDirectory, null, CloudBuild.Active);
         }

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -19,6 +19,10 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
   </PropertyGroup>
+  <PropertyGroup>
+    <!-- LibGit2Sharp Native Binary version - used in both main project and Cake addin -->
+    <LibGit2SharpNativeVersion>2.0.298</LibGit2SharpNativeVersion>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19367-01" PrivateAssets="All" />
   </ItemGroup>

--- a/src/NerdBank.GitVersioning/GitExtensions.cs
+++ b/src/NerdBank.GitVersioning/GitExtensions.cs
@@ -353,7 +353,18 @@
         /// <exception cref="ArgumentException">Thrown if the provided path does not lead to an existing directory.</exception>
         public static void HelpFindLibGit2NativeBinaries(string basePath)
         {
-            if (!TryHelpFindLibGit2NativeBinaries(basePath, out string attemptedDirectory))
+            HelpFindLibGit2NativeBinaries(basePath, out string _);
+        }
+
+        /// <summary>
+        /// Assists the operating system in finding the appropriate native libgit2 module.
+        /// </summary>
+        /// <param name="basePath">The path to the directory that contains the lib folder.</param>
+        /// <param name="attemptedDirectory">Receives the directory that native binaries are expected.</param>
+        /// <exception cref="ArgumentException">Thrown if the provided path does not lead to an existing directory.</exception>
+        public static void HelpFindLibGit2NativeBinaries(string basePath, out string attemptedDirectory)
+        {
+            if (!TryHelpFindLibGit2NativeBinaries(basePath, out attemptedDirectory))
             {
                 throw new ArgumentException($"Unable to find native binaries under directory: \"{attemptedDirectory}\".");
             }
@@ -366,7 +377,7 @@
         /// <returns><c>true</c> if the libgit2 native binaries have been found; <c>false</c> otherwise.</returns>
         public static bool TryHelpFindLibGit2NativeBinaries(string basePath)
         {
-            return TryHelpFindLibGit2NativeBinaries(basePath, out string attemptedDirectory);
+            return TryHelpFindLibGit2NativeBinaries(basePath, out string _);
         }
 
         /// <summary>

--- a/src/Nerdbank.GitVersioning.Tasks/Nerdbank.GitVersioning.Tasks.csproj
+++ b/src/Nerdbank.GitVersioning.Tasks/Nerdbank.GitVersioning.Tasks.csproj
@@ -18,7 +18,7 @@
 
   <Target Name="SetNuSpecProperties" BeforeTargets="GenerateNuspec" DependsOnTargets="GetBuildVersion">
     <PropertyGroup>
-      <LibGit2SharpNativeBinaries>$(NuGetPackageRoot)libgit2sharp.nativebinaries\2.0.298\</LibGit2SharpNativeBinaries>
+      <LibGit2SharpNativeBinaries>$(NuGetPackageRoot)libgit2sharp.nativebinaries\$(LibGit2SharpNativeVersion)\</LibGit2SharpNativeBinaries>
       <NuspecProperties>$(NuspecProperties);Version=$(Version);commit=$(GitCommitId);BaseOutputPath=$(OutputPath);LibGit2SharpNativeBinaries=$(LibGit2SharpNativeBinaries)</NuspecProperties>
     </PropertyGroup>
   </Target>


### PR DESCRIPTION
Fixes #365 

The native binaries are now included in the Cake.GitVersioning NuGet package, like they are in the Nerdbank.GitVersioning NuGet package, but with a different structure.  
Unlike the main project, which uses a nuspec file, this uses only the csproj file.

Despite the fact that the directory containing the native binary was successfully added to the PATH, the Cake addin was still throwing a DllNotFoundException.  I got around this by using the existing native binary locator and copying the native DLL to the root of the Cake addin at runtime.

Have successfully tested using NetFx, and NetCore & Mono on both Windows & Linux.  There are no automated tests because none existed for the Cake addin.