### PR TITLE
Fix bad libgit2-*.so path in nuspec

### DIFF
--- a/src/Nerdbank.GitVersioning.Tasks/Nerdbank.GitVersioning.nuspec
+++ b/src/Nerdbank.GitVersioning.Tasks/Nerdbank.GitVersioning.nuspec
@@ -27,7 +27,7 @@ IMPORTANT: The 3.x release may produce a different version height than prior maj
 
     <!-- Additional copies to work around DllNotFoundException on Mono (https://github.com/dotnet/Nerdbank.GitVersioning/issues/222) -->
     <file src="$LibGit2SharpNativeBinaries$runtimes\osx\native\libgit2-106a5f2.dylib" target="build\MSBuildFull\lib\osx\libgit2-106a5f2.dylib" />
-    <file src="$LibGit2SharpNativeBinaries$runtimes\linux-x64\native\libgit2-106a5f2.so" target="build\MSBuildFull\lib\linux\x86_64\libgit2-106a5f2.so" />
+    <file src="$LibGit2SharpNativeBinaries$runtimes\linux-x64\native\libgit2-106a5f2.so" target="build\MSBuildFull\lib\linux-x64\libgit2-106a5f2.so" />
 
     <!-- Additional copies to work with our own ps1 scripts (https://github.com/dotnet/Nerdbank.GitVersioning/issues/248) -->
     <file src="$LibGit2SharpNativeBinaries$runtimes\win-x64\native\git2-106a5f2.dll" target="build\MSBuildFull\lib\win32\x64\git2-106a5f2.dll" />


### PR DESCRIPTION
Fixes #417

Thanks for @kglassmire for discovering this root cause.