### PR TITLE
pathFilters paths should be relative to the version.json

### DIFF
--- a/doc/pathFilters.md
+++ b/doc/pathFilters.md
@@ -50,10 +50,10 @@ Path filters take on a variety of formats, and can specify paths relative to the
 
 Multiple path filters may also be specified. The order is irrelevant. After a path matches any non-exclude path filter, it will be run through all exclude path filter. If it matches, the path is ignored.
 
-| Path filter                                                                         | Description                                                                                                |
-| ----------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
-| `file-here.txt`<br>`./quux.txt`<br>`./sub-dir/foo.txt`<br>`../subdir/inclusion.txt` | File will be included. Path is relative to the `version.json` file.                                        |
-| `sub-dir`<br>`../sub-dir`                                                           | Directory will be included. Path is relative to the `version.json` file.                                   |
-| `:/dir/file.txt`                                                                    | File will be included. Path is absolute (i.e., relative to the root of the repository).                    |
-| `:!bar.txt`<br>`:^../foo/baz.txt`                                                   | File will be excluded. Path is relative to the `version.json` file. `:!` and `:^` prefixes are synonymous. |
-| `:!/root-file.txt`                                                                  | File will be excluded. Path is absolute (i.e., relative to the root of the repository).                    |
+| Path filter                                                                        | Description                                                                                                |
+| ---------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `./quux.txt`<br>`file-here.txt`<br>`sub-dir/foo.txt`<br>`../sibling/inclusion.txt` | File will be included. Path is relative to the `version.json` file.                                        |
+| `./`<br>`sub-dir`<br>`../sibling`                                                  | Directory will be included. Path is relative to the `version.json` file.                                   |
+| `/root-file.txt`<br>`:/dir/file.txt`                                               | File will be included. Path is absolute (i.e., relative to the root of the repository).                    |
+| `:!bar.txt`<br>`:^../foo/baz.txt`                                                  | File will be excluded. Path is relative to the `version.json` file. `:!` and `:^` prefixes are synonymous. |
+| `:!/root-file.txt`                                                                 | File will be excluded. Path is absolute (i.e., relative to the root of the repository).                    |

--- a/src/NerdBank.GitVersioning.Tests/NerdBank.GitVersioning.Tests.csproj
+++ b/src/NerdBank.GitVersioning.Tests/NerdBank.GitVersioning.Tests.csproj
@@ -10,7 +10,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\Shared\**\*.cs" LinkBase="Shared" />
-    <Compile Include="..\NerdBank.GitVersioning\FilterPath.cs" Link="FilterPath.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="..\Nerdbank.GitVersioning.Tasks\build\Nerdbank.GitVersioning.targets">

--- a/src/NerdBank.GitVersioning.Tests/ReleaseManagerTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/ReleaseManagerTests.cs
@@ -126,8 +126,6 @@ public class ReleaseManagerTests : RepoTestBase
 
         // create and configure repository
         this.InitializeSourceControl();
-        this.Repo.Config.Set("user.name", this.Signer.Name, ConfigurationLevel.Local);
-        this.Repo.Config.Set("user.email", this.Signer.Email, ConfigurationLevel.Local);
 
         var initialVersionOptions = new VersionOptions()
         {
@@ -182,8 +180,6 @@ public class ReleaseManagerTests : RepoTestBase
     {
         // create and configure repository
         this.InitializeSourceControl();
-        this.Repo.Config.Set("user.name", this.Signer.Name, ConfigurationLevel.Local);
-        this.Repo.Config.Set("user.email", this.Signer.Email, ConfigurationLevel.Local);
 
         // create version.json
         var versionOptions = new VersionOptions() { Version = SemanticVersion.Parse(initialVersion) };
@@ -256,8 +252,6 @@ public class ReleaseManagerTests : RepoTestBase
     {
         // create and configure repository
         this.InitializeSourceControl();
-        this.Repo.Config.Set("user.name", this.Signer.Name, ConfigurationLevel.Local);
-        this.Repo.Config.Set("user.email", this.Signer.Email, ConfigurationLevel.Local);
 
         // create version.json
         var initialVersionOptions = new VersionOptions()
@@ -365,8 +359,6 @@ public class ReleaseManagerTests : RepoTestBase
     {
         // create and configure repository
         this.InitializeSourceControl();
-        this.Repo.Config.Set("user.name", this.Signer.Name, ConfigurationLevel.Local);
-        this.Repo.Config.Set("user.email", this.Signer.Email, ConfigurationLevel.Local);
 
         // create version.json
         var versionOptions = new VersionOptions() { Version = SemanticVersion.Parse(initialVersion) };
@@ -394,8 +386,6 @@ public class ReleaseManagerTests : RepoTestBase
     {
         // create and configure repository
         this.InitializeSourceControl();
-        this.Repo.Config.Set("user.name", this.Signer.Name, ConfigurationLevel.Local);
-        this.Repo.Config.Set("user.email", this.Signer.Email, ConfigurationLevel.Local);
 
         // create version.json
         var versionOptions = new VersionOptions()

--- a/src/NerdBank.GitVersioning.Tests/RepoTestBase.cs
+++ b/src/NerdBank.GitVersioning.Tests/RepoTestBase.cs
@@ -72,6 +72,8 @@ public abstract class RepoTestBase : IDisposable
     {
         Repository.Init(this.RepoPath);
         this.Repo = new Repository(this.RepoPath);
+        this.Repo.Config.Set("user.name", this.Signer.Name, ConfigurationLevel.Local);
+        this.Repo.Config.Set("user.email", this.Signer.Email, ConfigurationLevel.Local);
         foreach (var file in this.Repo.RetrieveStatus().Untracked)
         {
             Commands.Stage(this.Repo, file.FilePath);

--- a/src/NerdBank.GitVersioning.Tests/VersionFileTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/VersionFileTests.cs
@@ -148,7 +148,6 @@ public class VersionFileTests : RepoTestBase
             }
         };
 
-        // TODO: assert message is helpful, e.g. "<path> is not in a Git repository"
         Assert.Throws<ArgumentNullException>(() => VersionFile.SetVersion(this.RepoPath, versionOptions));
     }
 
@@ -452,7 +451,6 @@ public class VersionFileTests : RepoTestBase
         var path = Path.Combine(this.RepoPath, "version.json");
         File.WriteAllText(path, json);
 
-        // TODO: assert message is helpful, e.g. "<path> is not in a Git repository"
         Assert.Throws<ArgumentNullException>(() => VersionFile.GetVersion(this.RepoPath));
     }
 

--- a/src/NerdBank.GitVersioning/FilterPathJsonConverter.cs
+++ b/src/NerdBank.GitVersioning/FilterPathJsonConverter.cs
@@ -1,0 +1,48 @@
+﻿namespace Nerdbank.GitVersioning
+{
+    using System;
+    using System.Reflection;
+    using Newtonsoft.Json;
+
+    internal class FilterPathJsonConverter : JsonConverter
+    {
+        private readonly string repoRelativeBaseDirectory;
+
+        public FilterPathJsonConverter(string repoRelativeBaseDirectory)
+        {
+            this.repoRelativeBaseDirectory = repoRelativeBaseDirectory;
+        }
+
+        public override bool CanConvert(Type objectType) => typeof(FilterPath).GetTypeInfo().IsAssignableFrom(objectType.GetTypeInfo());
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            if (objectType != typeof(FilterPath) || !(reader.Value is string value))
+            {
+                throw new NotSupportedException();
+            }
+
+            if (this.repoRelativeBaseDirectory == null)
+            {
+                throw new ArgumentNullException(nameof(this.repoRelativeBaseDirectory), $"Base directory must not be null to be able to deserialize filter paths. Did you forget to pass one to {nameof(VersionOptions.GetJsonSettings)}?");
+            }
+
+            return new FilterPath(value, this.repoRelativeBaseDirectory);
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            if (!(value is FilterPath filterPath))
+            {
+                throw new NotSupportedException();
+            }
+
+            if (this.repoRelativeBaseDirectory == null)
+            {
+                throw new ArgumentNullException(nameof(this.repoRelativeBaseDirectory), $"Base directory must not be null to be able to serialize filter paths. Did you forget to pass one to {nameof(VersionOptions.GetJsonSettings)}?");
+            }
+
+            writer.WriteValue(filterPath.ToPathSpec(this.repoRelativeBaseDirectory));
+        }
+    }
+}

--- a/src/NerdBank.GitVersioning/FilterPathJsonConverter.cs
+++ b/src/NerdBank.GitVersioning/FilterPathJsonConverter.cs
@@ -24,7 +24,7 @@
 
             if (this.repoRelativeBaseDirectory == null)
             {
-                throw new ArgumentNullException(nameof(this.repoRelativeBaseDirectory), $"Base directory must not be null to be able to deserialize filter paths. Did you forget to pass one to {nameof(VersionOptions.GetJsonSettings)}?");
+                throw new ArgumentNullException(nameof(this.repoRelativeBaseDirectory), $"Base directory must not be null to be able to deserialize filter paths. Ensure that one was passed to {nameof(VersionOptions.GetJsonSettings)}, and that the version.json file is being written to a Git repository.");
             }
 
             return new FilterPath(value, this.repoRelativeBaseDirectory);
@@ -39,7 +39,7 @@
 
             if (this.repoRelativeBaseDirectory == null)
             {
-                throw new ArgumentNullException(nameof(this.repoRelativeBaseDirectory), $"Base directory must not be null to be able to serialize filter paths. Did you forget to pass one to {nameof(VersionOptions.GetJsonSettings)}?");
+                throw new ArgumentNullException(nameof(this.repoRelativeBaseDirectory), $"Base directory must not be null to be able to serialize filter paths. Ensure that one was passed to {nameof(VersionOptions.GetJsonSettings)}, and that the version.json file is being written to a Git repository.");
             }
 
             writer.WriteValue(filterPath.ToPathSpec(this.repoRelativeBaseDirectory));

--- a/src/NerdBank.GitVersioning/GitExtensions.cs
+++ b/src/NerdBank.GitVersioning/GitExtensions.cs
@@ -927,12 +927,16 @@
                 repoRoot = repo.Info.Path.Substring(0, 2) + repoRoot;
             }
 
-            // TODO: assert that absolutePath starts with repoRoot?
+            if (repoRoot == null)
+                return null;
 
-            return !string.IsNullOrWhiteSpace(repoRoot)
-                ? absolutePath.Substring(repoRoot.Length)
-                    .TrimStart(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
-                : null;
+            if (!absolutePath.StartsWith(repoRoot, StringComparison.OrdinalIgnoreCase))
+            {
+                throw new ArgumentException($"Path '{absolutePath}' is not within repository '{repoRoot}'", nameof(absolutePath));
+            }
+
+            return absolutePath.Substring(repoRoot.Length)
+                .TrimStart(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
         }
 
         private class GitWalkTracker

--- a/src/NerdBank.GitVersioning/VersionOracle.cs
+++ b/src/NerdBank.GitVersioning/VersionOracle.cs
@@ -55,19 +55,7 @@
         /// </summary>
         public VersionOracle(string projectDirectory, LibGit2Sharp.Repository repo, LibGit2Sharp.Commit head, ICloudBuild cloudBuild, int? overrideVersionHeightOffset = null, string projectPathRelativeToGitRepoRoot = null)
         {
-            var repoRoot = repo?.Info?.WorkingDirectory?.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && repoRoot != null && repoRoot.StartsWith("\\") && (repoRoot.Length == 1 || repoRoot[1] != '\\'))
-            {
-                // We're in a worktree, which libgit2sharp only gives us as a path relative to the root of the assumed drive.
-                // Add the drive: to the front of the repoRoot.
-                repoRoot = repo.Info.Path.Substring(0, 2) + repoRoot;
-            }
-
-            var relativeRepoProjectDirectory = !string.IsNullOrWhiteSpace(repoRoot)
-                ? (!string.IsNullOrEmpty(projectPathRelativeToGitRepoRoot)
-                    ? projectPathRelativeToGitRepoRoot
-                    : projectDirectory.Substring(repoRoot.Length).TrimStart(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar))
-                : null;
+            var relativeRepoProjectDirectory = projectPathRelativeToGitRepoRoot ?? repo?.GetRepoRelativePath(projectDirectory);
 
             var commit = head ?? repo?.Head.Tip;
 


### PR DESCRIPTION
Fixes #451. Path were incorrectly relative to the project directory.

This PR ended up being a bit more an invasive change than I initially anticipated. This is because the JSON serialisation code understandably had no notion of _where_ the version.json was being written to.

### Changes

- VersionFile.SetVersion/GetVersion must point to version.json files that reside in a Git repository to be able to serialize/deserialize path filters
- FilterPath is now part of the public API, and is used on the `VersionFile` class
- Added lots of tests :)