### PR TITLE
Set BuildingRef as output property from GetBuildVersion

### DIFF
--- a/src/NerdBank.GitVersioning/VersionOracle.cs
+++ b/src/NerdBank.GitVersioning/VersionOracle.cs
@@ -272,7 +272,10 @@
         /// </summary>
         public int VersionHeightOffset { get; }
 
-        private string BuildingRef { get; }
+        /// <summary>
+        /// Gets the ref (branch or tag) being built.
+        /// </summary>
+        public string BuildingRef { get; }
 
         /// <summary>
         /// Gets the version for this project, with up to 4 components.

--- a/src/Nerdbank.GitVersioning.Tasks/GetBuildVersion.cs
+++ b/src/Nerdbank.GitVersioning.Tasks/GetBuildVersion.cs
@@ -21,11 +21,6 @@
         }
 
         /// <summary>
-        /// Gets or sets the ref (branch or tag) being built.
-        /// </summary>
-        public string BuildingRef { get; set; }
-
-        /// <summary>
         /// Gets or sets identifiers to append as build metadata.
         /// </summary>
         public string[] BuildMetadata { get; set; }
@@ -79,11 +74,10 @@
         public bool PublicRelease { get; private set; }
 
         /// <summary>
-        /// Gets the ref (branch or tag) being built.
-        /// Only specified when this is not a public release.
+        /// Gets or sets the ref (branch or tag) being built.
         /// </summary>
         [Output]
-        public string PrivateReleaseGitRef { get; set; }
+        public string BuildingRef { get; set; }
 
         /// <summary>
         /// Gets the version string to use in the compiled assemblies.
@@ -225,7 +219,7 @@
                 }
 
                 this.PublicRelease = oracle.PublicRelease;
-                this.PrivateReleaseGitRef = this.PublicRelease ? null : oracle.BuildingRef;
+                this.BuildingRef = oracle.BuildingRef;
                 this.Version = oracle.Version.ToString();
                 this.AssemblyVersion = oracle.AssemblyVersion.ToString();
                 this.AssemblyFileVersion = oracle.AssemblyFileVersion.ToString();

--- a/src/Nerdbank.GitVersioning.Tasks/GetBuildVersion.cs
+++ b/src/Nerdbank.GitVersioning.Tasks/GetBuildVersion.cs
@@ -79,6 +79,13 @@
         public bool PublicRelease { get; private set; }
 
         /// <summary>
+        /// Gets the ref (branch or tag) being built.
+        /// Only specified when this is not a public release.
+        /// </summary>
+        [Output]
+        public string PrivateReleaseGitRef { get; set; }
+
+        /// <summary>
         /// Gets the version string to use in the compiled assemblies.
         /// </summary>
         [Output]
@@ -218,6 +225,7 @@
                 }
 
                 this.PublicRelease = oracle.PublicRelease;
+                this.PrivateReleaseGitRef = this.PublicRelease ? null : oracle.BuildingRef;
                 this.Version = oracle.Version.ToString();
                 this.AssemblyVersion = oracle.AssemblyVersion.ToString();
                 this.AssemblyFileVersion = oracle.AssemblyFileVersion.ToString();

--- a/src/Nerdbank.GitVersioning.Tasks/build/Nerdbank.GitVersioning.targets
+++ b/src/Nerdbank.GitVersioning.Tasks/build/Nerdbank.GitVersioning.targets
@@ -92,6 +92,7 @@
       <Output TaskParameter="BuildNumber" PropertyName="BuildNumber" />
       <Output TaskParameter="BuildNumber" PropertyName="BuildVersionNumberComponent" />
       <Output TaskParameter="PublicRelease" PropertyName="PublicRelease" />
+      <Output TaskParameter="PrivateReleaseGitRef" PropertyName="PrivateReleaseGitRef" />
       <Output TaskParameter="CloudBuildNumber" PropertyName="CloudBuildNumber" Condition=" '$(CloudBuildNumber)' == '' "/>
       <Output TaskParameter="BuildMetadataFragment" PropertyName="SemVerBuildSuffix" />
       <Output TaskParameter="NuGetPackageVersion" PropertyName="NuGetPackageVersion" />

--- a/src/Nerdbank.GitVersioning.Tasks/build/Nerdbank.GitVersioning.targets
+++ b/src/Nerdbank.GitVersioning.Tasks/build/Nerdbank.GitVersioning.targets
@@ -92,7 +92,7 @@
       <Output TaskParameter="BuildNumber" PropertyName="BuildNumber" />
       <Output TaskParameter="BuildNumber" PropertyName="BuildVersionNumberComponent" />
       <Output TaskParameter="PublicRelease" PropertyName="PublicRelease" />
-      <Output TaskParameter="PrivateReleaseGitRef" PropertyName="PrivateReleaseGitRef" />
+      <Output TaskParameter="BuildingRef" PropertyName="BuildingRef" />
       <Output TaskParameter="CloudBuildNumber" PropertyName="CloudBuildNumber" Condition=" '$(CloudBuildNumber)' == '' "/>
       <Output TaskParameter="BuildMetadataFragment" PropertyName="SemVerBuildSuffix" />
       <Output TaskParameter="NuGetPackageVersion" PropertyName="NuGetPackageVersion" />


### PR DESCRIPTION
It's not a good idea to take a dependency on a branch name. At the same time, branches are too useful to ignore. The `PublicRelease` functionality depends on them.
The argument can go one step further: during development (in non-public releases), branch names in version numbers are useful for traceability: e.g. `1.0.0-g1234567+PR1512` or `1.0.0-g1234567+BalpineLinux`

It would be easiest to extend NBGV-produced version numbers in the way above if NBGV also provided access to build refs.