### PR TITLE
Add JSON output option to 'prepare-release' command

### DIFF
--- a/doc/nbgv-cli.md
+++ b/doc/nbgv-cli.md
@@ -121,6 +121,49 @@ The behaviour of the `prepare-release` command can be customized in
 | versionIncrement | `minor`              | Specifies which part of the version on the current branch is incremented when preparing a release. Allowed values are `major`, `minor` and `build`. |
 | firstUnstableTag | `alpha`              | Specified the unstable tag to use for the main branch.                                                                                              |
 
+### Customizing the `prepare-release` output format
+
+By default, the `prepare-release` command writes information about created and updated branches to the console as text.
+Alternatively the information can be written to the output as `json`.
+The output format to use can be set using the `--format` command line parameter.
+
+For example, running the follwoing command on `master`
+
+```
+nbgv prepare-release --format json
+```
+
+will generate output similar to this:
+
+```json
+{
+  "CurrentBranch": {
+    "Name": "master",
+    "Commit": "5a7487098ac1be1ceb4dbf72d862539cf0b0c27a",
+    "Version": "1.7-alpha"
+  },
+  "NewBranch": {
+    "Name": "v1.7",
+    "Commit": "b2f164675ffe891b66b601c00efc4343581fc8a5",
+    "Version": "1.7"
+  }
+}
+```
+
+The JSON object has to properties:
+
+- `CurrentBranch` provides information about the branch `prepare-release` was started on (typically `master`)
+- `NewBranch` provides information about the new branch created by the command.
+
+For each branch, the following proprties are provided:
+
+- `Name`: The name of the branch
+- `Commit`: The id of the latest commit on that branch
+- `Version`: The version configured in that branch's `version.json`
+
+**Note:** When the current branch is already the release branch for the current version, no new branch will be created.
+In that case, the `NewBranch` property will be `null`.
+
 ## Learn more
 
 There are several more sub-commands and switches to each to help you build and maintain your projects, find a commit that built a particular version later on, create tags, etc.

--- a/src/NerdBank.GitVersioning/ReleaseManager.cs
+++ b/src/NerdBank.GitVersioning/ReleaseManager.cs
@@ -115,11 +115,7 @@
             [JsonConstructor]
             public ReleaseInfo(ReleaseBranchInfo currentBranch, ReleaseBranchInfo newBranch)
             {
-                if(currentBranch == null)
-                {
-                    throw new ArgumentNullException(nameof(currentBranch), $"{nameof(this.CurrentBranch)} can't be empty");
-                }
-                
+                Requires.NotNull(currentBranch, nameof(currentBranch));                
                 // skip null check for newBranch, it is allowed to be null.
 
                 this.CurrentBranch = currentBranch;                
@@ -155,20 +151,9 @@
             /// <param name="version">The version configured in the branch's <c>version.json</c>.</param>
             public ReleaseBranchInfo(string name, string commit, SemanticVersion version)
             {
-                if (string.IsNullOrWhiteSpace(name))
-                {
-                    throw new ArgumentNullException(nameof(name), $"{nameof(this.Name)} can't be empty");
-                }
-
-                if (string.IsNullOrWhiteSpace(commit))
-                {
-                    throw new ArgumentNullException(nameof(commit), $"{nameof(this.Commit)} can't be empty");
-                }
-
-                if(version == null)
-                {
-                    throw new ArgumentNullException(nameof(version), $"{nameof(this.Version)} can't be empty");
-                }
+                Requires.NotNullOrWhiteSpace(name, nameof(name));
+                Requires.NotNullOrWhiteSpace(commit, nameof(commit));
+                Requires.NotNull(version, nameof(version));
 
                 this.Name = name;
                 this.Commit = commit;

--- a/src/NerdBank.GitVersioning/ReleaseManager.cs
+++ b/src/NerdBank.GitVersioning/ReleaseManager.cs
@@ -4,6 +4,7 @@
     using System.Collections.Generic;
     using System.IO;
     using LibGit2Sharp;
+    using Newtonsoft.Json;
     using Validation;
     using Version = System.Version;
 
@@ -81,36 +82,37 @@
         }
 
         /// <summary>
-        /// Encapsulates information on a release created through <see cref="ReleaseManager"/>
+        /// Encapsulates information on a release created through <see cref="ReleaseManager"/>.
         /// </summary>
         public class ReleaseInfo
         {
             /// <summary>
-            /// Gets information on the 'current' branch, i.e. the branch the release was created from
+            /// Gets information on the 'current' branch, i.e. the branch the release was created from.
             /// </summary>
             public ReleaseBranchInfo CurrentBranch { get; }
 
             /// <summary>
-            /// Gets information on the new branch created by <see cref="ReleaseManager"/>
+            /// Gets information on the new branch created by <see cref="ReleaseManager"/>.
             /// </summary>
             /// <value>
-            /// Information on the newly created branch as instance of <see cref="ReleaseBranchInfo"/> or <c>null</c>, if no new branch was created
+            /// Information on the newly created branch as instance of <see cref="ReleaseBranchInfo"/> or <c>null</c>, if no new branch was created.
             /// </value>
             [JsonProperty(DefaultValueHandling = DefaultValueHandling.Include)]
             public ReleaseBranchInfo NewBranch { get; }
 
             /// <summary>
-            /// Initializes a new instance of <see cref="ReleaseInfo"/>
+            /// Initializes a new instance of <see cref="ReleaseInfo"/>.
             /// </summary>
             /// <param name="currentBranch">Information on the branch the release was created from.</param>
             public ReleaseInfo(ReleaseBranchInfo currentBranch) : this(currentBranch, null)
             { }
 
             /// <summary>
-            /// Initializes a new instance of <see cref="ReleaseInfo"/>
+            /// Initializes a new instance of <see cref="ReleaseInfo"/>.
             /// </summary>
             /// <param name="currentBranch">Information on the branch the release was created from.</param>
             /// <param name="newBranch">Information on the newly created branch.</param>
+            [JsonConstructor]
             public ReleaseInfo(ReleaseBranchInfo currentBranch, ReleaseBranchInfo newBranch)
             {
                 if(currentBranch == null)
@@ -126,31 +128,31 @@
         }
 
         /// <summary>
-        /// Encapsulates information on a branch created or updated by <see cref="ReleaseManager"/>
+        /// Encapsulates information on a branch created or updated by <see cref="ReleaseManager"/>.
         /// </summary>
         public class ReleaseBranchInfo
         {
             /// <summary>
-            /// The name of the branch, e.g. <c>master</c>
+            /// The name of the branch, e.g. <c>master</c>.
             /// </summary>
             public string Name { get; }
 
             /// <summary>
-            /// The id of the branch's tip commit after the update
+            /// The id of the branch's tip commit after the update.
             /// </summary>
             public string Commit { get; }
 
             /// <summary>
-            /// The version configured in the branch's <c>version.json</c>
+            /// The version configured in the branch's <c>version.json</c>.
             /// </summary>
             public SemanticVersion Version { get; }
 
             /// <summary>
-            /// Initializes a new instance of <see cref="ReleaseBranchInfo"/>
+            /// Initializes a new instance of <see cref="ReleaseBranchInfo"/>.
             /// </summary>
-            /// <param name="name">The name of the branch</param>
-            /// <param name="commit">The id of the branch's tip</param>
-            /// <param name="version">The version configured in the branch's <c>version.json</c></param>
+            /// <param name="name">The name of the branch.</param>
+            /// <param name="commit">The id of the branch's tip.</param>
+            /// <param name="version">The version configured in the branch's <c>version.json</c>.</param>
             public ReleaseBranchInfo(string name, string commit, SemanticVersion version)
             {
                 if (string.IsNullOrWhiteSpace(name))
@@ -174,11 +176,27 @@
             }
         }
 
+        /// <summary>
+        /// Enumerates the output formats supported by <see cref="ReleaseManager"/>.
+        /// </summary>
+        public enum ReleaseManagerOutputMode
+        {
+            /// <summary>
+            /// Use unstructured text output.
+            /// </summary>
+            Text = 0,
+            /// <summary>
+            /// Output information about the release as JSON.
+            /// </summary>
+            Json = 1
+        }
+
+
         private readonly TextWriter stdout;
         private readonly TextWriter stderr;
 
         /// <summary>
-        /// Initializes a new instance of <see cref="ReleaseManager"/>
+        /// Initializes a new instance of <see cref="ReleaseManager"/>.
         /// </summary>
         /// <param name="outputWriter">The <see cref="TextWriter"/> to write output to (e.g. <see cref="Console.Out" />).</param>
         /// <param name="errorWriter">The <see cref="TextWriter"/> to write error messages to (e.g. <see cref="Console.Error" />).</param>
@@ -209,7 +227,10 @@
         /// If specified, value will be used instead of the increment specified in <c>version.json</c>.
         /// Parameter will be ignored if the current branch is a release branch.
         /// </param>
-        public void PrepareRelease(string projectDirectory, string releaseUnstableTag = null, Version nextVersion = null, VersionOptions.ReleaseVersionIncrement? versionIncrement = null)
+        /// <param name="outputMode">
+        /// The output format to use for writing to stdout.
+        /// </param>
+        public void PrepareRelease(string projectDirectory, string releaseUnstableTag = null, Version nextVersion = null, VersionOptions.ReleaseVersionIncrement? versionIncrement = null, ReleaseManagerOutputMode outputMode = default)
         {
             Requires.NotNull(projectDirectory, nameof(projectDirectory));
 
@@ -239,7 +260,15 @@
             // check if the current branch is the release branch
             if (string.Equals(originalBranchName, releaseBranchName, StringComparison.OrdinalIgnoreCase))
             {
-                this.stdout.WriteLine($"{releaseBranchName} branch advanced from {versionOptions.Version} to {releaseVersion}.");
+                if(outputMode == ReleaseManagerOutputMode.Text)
+                {
+                    this.stdout.WriteLine($"{releaseBranchName} branch advanced from {versionOptions.Version} to {releaseVersion}.");
+                }
+                else
+                {
+                    var releaseInfo = new ReleaseInfo(new ReleaseBranchInfo(releaseBranchName, repository.Head.Tip.Id.ToString(), releaseVersion));
+                    this.WriteToOutput(releaseInfo);
+                }
                 this.UpdateVersion(projectDirectory, repository, versionOptions.Version, releaseVersion);
                 return;
             }
@@ -257,12 +286,20 @@
             var releaseBranch = repository.CreateBranch(releaseBranchName);
             Commands.Checkout(repository, releaseBranch);
             this.UpdateVersion(projectDirectory, repository, versionOptions.Version, releaseVersion);
-            this.stdout.WriteLine($"{releaseBranchName} branch now tracks v{releaseVersion} stabilization and release.");
+
+            if (outputMode == ReleaseManagerOutputMode.Text)
+            {
+                this.stdout.WriteLine($"{releaseBranchName} branch now tracks v{releaseVersion} stabilization and release.");
+            }
 
             // update version on main branch
             Commands.Checkout(repository, originalBranchName);
             this.UpdateVersion(projectDirectory, repository, versionOptions.Version, nextDevVersion);
-            this.stdout.WriteLine($"{originalBranchName} branch now tracks v{nextDevVersion} development.");
+
+            if(outputMode == ReleaseManagerOutputMode.Text)
+            {
+                this.stdout.WriteLine($"{originalBranchName} branch now tracks v{nextDevVersion} development.");                 
+            }
 
             // Merge release branch back to main branch
             var mergeOptions = new MergeOptions()
@@ -271,6 +308,14 @@
                 MergeFileFavor = MergeFileFavor.Ours,
             };
             repository.Merge(releaseBranch, this.GetSignature(repository), mergeOptions);
+
+            if(outputMode == ReleaseManagerOutputMode.Json)
+            {
+                var currentBranchInfo = new ReleaseBranchInfo(originalBranchName, repository.Branches[originalBranchName].Tip.Id.ToString(), nextDevVersion);
+                var releaseBranchInfo = new ReleaseBranchInfo(releaseBranchName, repository.Branches[releaseBranchName].Tip.Id.ToString(), releaseVersion);
+                var releaseInfo = new ReleaseInfo(currentBranchInfo, releaseBranchInfo);
+                this.WriteToOutput(releaseInfo);
+            }            
         }
 
         private string GetReleaseBranchName(VersionOptions versionOptions)
@@ -405,6 +450,12 @@
 
             // return next version with prerelease tag specified in version.json
             return nextDevVersion.SetFirstPrereleaseTag(versionOptions.ReleaseOrDefault.FirstUnstableTagOrDefault);
+        }
+
+        private void WriteToOutput(ReleaseInfo releaseInfo)
+        {
+            var json = JsonConvert.SerializeObject(releaseInfo, Formatting.Indented, new SemanticVersionJsonConverter());
+            this.stdout.WriteLine(json);
         }
     }
 }

--- a/src/NerdBank.GitVersioning/ReleaseManager.cs
+++ b/src/NerdBank.GitVersioning/ReleaseManager.cs
@@ -115,11 +115,11 @@
             [JsonConstructor]
             public ReleaseInfo(ReleaseBranchInfo currentBranch, ReleaseBranchInfo newBranch)
             {
-                Requires.NotNull(currentBranch, nameof(currentBranch));                
+                Requires.NotNull(currentBranch, nameof(currentBranch));
                 // skip null check for newBranch, it is allowed to be null.
 
-                this.CurrentBranch = currentBranch;                
-                this.NewBranch = newBranch; 
+                this.CurrentBranch = currentBranch;
+                this.NewBranch = newBranch;
             }
         }
 
@@ -235,7 +235,7 @@
                 this.stderr.WriteLine($"Failed to load version file for directory '{projectDirectory}'.");
                 throw new ReleasePreparationException(ReleasePreparationError.NoVersionFile);
             }
-            
+
             var releaseBranchName = this.GetReleaseBranchName(versionOptions);
             var originalBranchName = repository.Head.FriendlyName;
             var releaseVersion = string.IsNullOrEmpty(releaseUnstableTag)
@@ -245,7 +245,7 @@
             // check if the current branch is the release branch
             if (string.Equals(originalBranchName, releaseBranchName, StringComparison.OrdinalIgnoreCase))
             {
-                if(outputMode == ReleaseManagerOutputMode.Text)
+                if (outputMode == ReleaseManagerOutputMode.Text)
                 {
                     this.stdout.WriteLine($"{releaseBranchName} branch advanced from {versionOptions.Version} to {releaseVersion}.");
                 }
@@ -281,9 +281,9 @@
             Commands.Checkout(repository, originalBranchName);
             this.UpdateVersion(projectDirectory, repository, versionOptions.Version, nextDevVersion);
 
-            if(outputMode == ReleaseManagerOutputMode.Text)
+            if (outputMode == ReleaseManagerOutputMode.Text)
             {
-                this.stdout.WriteLine($"{originalBranchName} branch now tracks v{nextDevVersion} development.");                 
+                this.stdout.WriteLine($"{originalBranchName} branch now tracks v{nextDevVersion} development.");
             }
 
             // Merge release branch back to main branch
@@ -294,14 +294,14 @@
             };
             repository.Merge(releaseBranch, this.GetSignature(repository), mergeOptions);
 
-            if(outputMode == ReleaseManagerOutputMode.Json)
+            if (outputMode == ReleaseManagerOutputMode.Json)
             {
                 var originalBranchInfo = new ReleaseBranchInfo(originalBranchName, repository.Head.Tip.Sha, nextDevVersion);
                 var releaseBranchInfo = new ReleaseBranchInfo(releaseBranchName, repository.Branches[releaseBranchName].Tip.Id.ToString(), releaseVersion);
                 var releaseInfo = new ReleaseInfo(originalBranchInfo, releaseBranchInfo);
 
                 this.WriteToOutput(releaseInfo);
-            }            
+            }
         }
 
         private string GetReleaseBranchName(VersionOptions versionOptions)
@@ -409,7 +409,7 @@
             var currentVersion = versionOptions.Version;
 
             SemanticVersion nextDevVersion;
-            if(nextVersionOverride != null)
+            if (nextVersionOverride != null)
             {
                 nextDevVersion = new SemanticVersion(nextVersionOverride, currentVersion.Prerelease, currentVersion.BuildMetadata);
             }

--- a/src/NerdBank.GitVersioning/ReleaseManager.cs
+++ b/src/NerdBank.GitVersioning/ReleaseManager.cs
@@ -80,6 +80,100 @@
             public ReleasePreparationException(ReleasePreparationError error) => this.Error = error;
         }
 
+        /// <summary>
+        /// Encapsulates information on a release created through <see cref="ReleaseManager"/>
+        /// </summary>
+        public class ReleaseInfo
+        {
+            /// <summary>
+            /// Gets information on the 'current' branch, i.e. the branch the release was created from
+            /// </summary>
+            public ReleaseBranchInfo CurrentBranch { get; }
+
+            /// <summary>
+            /// Gets information on the new branch created by <see cref="ReleaseManager"/>
+            /// </summary>
+            /// <value>
+            /// Information on the newly created branch as instance of <see cref="ReleaseBranchInfo"/> or <c>null</c>, if no new branch was created
+            /// </value>
+            [JsonProperty(DefaultValueHandling = DefaultValueHandling.Include)]
+            public ReleaseBranchInfo NewBranch { get; }
+
+            /// <summary>
+            /// Initializes a new instance of <see cref="ReleaseInfo"/>
+            /// </summary>
+            /// <param name="currentBranch">Information on the branch the release was created from.</param>
+            public ReleaseInfo(ReleaseBranchInfo currentBranch) : this(currentBranch, null)
+            { }
+
+            /// <summary>
+            /// Initializes a new instance of <see cref="ReleaseInfo"/>
+            /// </summary>
+            /// <param name="currentBranch">Information on the branch the release was created from.</param>
+            /// <param name="newBranch">Information on the newly created branch.</param>
+            public ReleaseInfo(ReleaseBranchInfo currentBranch, ReleaseBranchInfo newBranch)
+            {
+                if(currentBranch == null)
+                {
+                    throw new ArgumentNullException(nameof(currentBranch), $"{nameof(this.CurrentBranch)} can't be empty");
+                }
+                
+                // skip null check for newBranch, it is allowed to be null.
+
+                this.CurrentBranch = currentBranch;                
+                this.NewBranch = newBranch; 
+            }
+        }
+
+        /// <summary>
+        /// Encapsulates information on a branch created or updated by <see cref="ReleaseManager"/>
+        /// </summary>
+        public class ReleaseBranchInfo
+        {
+            /// <summary>
+            /// The name of the branch, e.g. <c>master</c>
+            /// </summary>
+            public string Name { get; }
+
+            /// <summary>
+            /// The id of the branch's tip commit after the update
+            /// </summary>
+            public string Commit { get; }
+
+            /// <summary>
+            /// The version configured in the branch's <c>version.json</c>
+            /// </summary>
+            public SemanticVersion Version { get; }
+
+            /// <summary>
+            /// Initializes a new instance of <see cref="ReleaseBranchInfo"/>
+            /// </summary>
+            /// <param name="name">The name of the branch</param>
+            /// <param name="commit">The id of the branch's tip</param>
+            /// <param name="version">The version configured in the branch's <c>version.json</c></param>
+            public ReleaseBranchInfo(string name, string commit, SemanticVersion version)
+            {
+                if (string.IsNullOrWhiteSpace(name))
+                {
+                    throw new ArgumentNullException(nameof(name), $"{nameof(this.Name)} can't be empty");
+                }
+
+                if (string.IsNullOrWhiteSpace(commit))
+                {
+                    throw new ArgumentNullException(nameof(commit), $"{nameof(this.Commit)} can't be empty");
+                }
+
+                if(version == null)
+                {
+                    throw new ArgumentNullException(nameof(version), $"{nameof(this.Version)} can't be empty");
+                }
+
+                this.Name = name;
+                this.Commit = commit;
+                this.Version = version;
+            }
+        }
+
         private readonly TextWriter stdout;
         private readonly TextWriter stderr;
 

--- a/src/NerdBank.GitVersioning/ReleaseManager.cs
+++ b/src/NerdBank.GitVersioning/ReleaseManager.cs
@@ -311,9 +311,10 @@
 
             if(outputMode == ReleaseManagerOutputMode.Json)
             {
-                var currentBranchInfo = new ReleaseBranchInfo(originalBranchName, repository.Branches[originalBranchName].Tip.Id.ToString(), nextDevVersion);
+                var originalBranchInfo = new ReleaseBranchInfo(originalBranchName, repository.Head.Tip.Sha, versionOptions.Version);
                 var releaseBranchInfo = new ReleaseBranchInfo(releaseBranchName, repository.Branches[releaseBranchName].Tip.Id.ToString(), releaseVersion);
-                var releaseInfo = new ReleaseInfo(currentBranchInfo, releaseBranchInfo);
+                var releaseInfo = new ReleaseInfo(originalBranchInfo, releaseBranchInfo);
+
                 this.WriteToOutput(releaseInfo);
             }            
         }

--- a/src/NerdBank.GitVersioning/ReleaseManager.cs
+++ b/src/NerdBank.GitVersioning/ReleaseManager.cs
@@ -311,7 +311,7 @@
 
             if(outputMode == ReleaseManagerOutputMode.Json)
             {
-                var originalBranchInfo = new ReleaseBranchInfo(originalBranchName, repository.Head.Tip.Sha, versionOptions.Version);
+                var originalBranchInfo = new ReleaseBranchInfo(originalBranchName, repository.Head.Tip.Sha, nextDevVersion);
                 var releaseBranchInfo = new ReleaseBranchInfo(releaseBranchName, repository.Branches[releaseBranchName].Tip.Id.ToString(), releaseVersion);
                 var releaseInfo = new ReleaseInfo(originalBranchInfo, releaseBranchInfo);
 


### PR DESCRIPTION
This PR adds a `--format` parameter to `prepare-release` that allows setting the output format to `json`.

I made some adjustments to the output format proposed in #481. 
The output will look like this:

```json
{
  "CurrentBranch": {
    "Name": "master",
    "Commit": "5a7487098ac1be1ceb4dbf72d862539cf0b0c27a",
    "Version": "0.3-pre"
  },
  "NewBranch": {
    "Name": "release/v0.2",
    "Commit": "b2f164675ffe891b66b601c00efc4343581fc8a5",
    "Version": "0.2"
  }
}
```
- The output includes the id of the latest commit on the respective branches. This way, the exact version on the branch can easily be queried using `get-version`.
- The property names use pascal-case instead of camel-case so the output is consistent with the JSON output of  `get-version`
- The properties `devBranch` and `releaseBranch` are named`CurrentBranch`(the branch the command was started on) and `NewBranch` (the new branch that was created) instead. 
  That way, the scenario that the command is started on the release branch can be handled as well. In that case, the `NewBranch` property will be `null` because no new branch was created.




Fixes #481