### PR TITLE
Floating version for detection of latest stable version

### DIFF
--- a/src/nbgv/Program.cs
+++ b/src/nbgv/Program.cs
@@ -241,15 +241,15 @@ namespace Nerdbank.GitVersioning.Tool
 
             const string PackageReferenceItemType = "PackageReference";
             const string PackageId = "Nerdbank.GitVersioning";
-            const string LatestStablePackageVersion = "*";
             if (!propsFile.GetItemsByEvaluatedInclude(PackageId).Any(i => i.ItemType == "PackageReference"))
             {
+                string packageVersion = $"{typeof(Program).GetTypeInfo().Assembly.GetName().Version.Major}.*";
                 propsFile.AddItem(
                     PackageReferenceItemType,
                     PackageId,
                     new Dictionary<string, string>
                     {
-                        { "Version", LatestStablePackageVersion },
+                        { "Version", packageVersion },
                         { "PrivateAssets", "all" },
                     });
 

--- a/src/nbgv/nbgv.csproj
+++ b/src/nbgv/nbgv.csproj
@@ -10,8 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NuGet.PackageManagement" Version="4.9.3" NoWarn="NU1701" />
-    <PackageReference Include="NuGet.Resolver" Version="4.9.3" />
     <PackageReference Include="System.CommandLine" Version="0.1.0-preview2-180503-2" />
     <PackageReference Include="Nerdbank.GitVersioning.LKG" Version="3.1.93" PrivateAssets="all" />
     <PackageReference Include="System.Diagnostics.Tools" Version="4.3.0" />


### PR DESCRIPTION
Hi,

I'm currently facing the issue that `ngbv install` fails on an environment where access to public NuGet package source (https://api.nuget.org/v3/index.json) is denied, which is used by the install-command:

```
Unhandled Exception:
   Cannot print exception string because Exception.ToString() failed.
```

This PR is a proposal to force automatical selection of the latest stable version of `Nerdbank.GitVersioning` by using floating versions, `*`. See https://github.com/NuGet/Home/wiki/Support-pre-release-packages-with-floating-versions to find more details on floating versions.

As a precaution, I verified that floating versions are compatible with old- and new-fashioned *.csproj by running the following tests with .NET Core console (ConsoleAppNew) and .NET Framework console (ConsoleAppOld) projects:

File structure:
```
ConsoleAppNew
  ConsoleAppNew
    ConsoleAppNew.csproj
    Program.cs
  ConsoleAppNew.sln
  Directory.Build.props
  version.json
ConsoleAppOld
  ConsoleAppOld
    Properties
      AssemblyInfo.cs
    App.config
    ConsoleAppOld.csproj
    Program.cs
  ConsoleAppOld.sln
  Directory.Build.props
  version.json
```

Directory.Build.props:
```
<Project>

  <ItemGroup>
    <PackageReference Include="Nerdbank.GitVersioning">
      <Version>*</Version>
      <PrivateAssets>all</PrivateAssets>
    </PackageReference>
  </ItemGroup>

</Project>
```

Latest version of `Nerdbank.GitVersioning` at the time of the test: `3.2.31`

```
ConsoleAppNew>dotnet build
ConsoleAppNew>type ConsoleAppNew\obj\Debug\netcoreapp3.1\ConsoleAppNew.Version.cs
...
[assembly: System.Reflection.AssemblyInformationalVersionAttribute("1.0.2-new+c24df8c31b")]
#if NETSTANDARD || NETFRAMEWORK || NETCOREAPP
[System.CodeDom.Compiler.GeneratedCode("Nerdbank.GitVersioning.Tasks","3.2.31.56335")]
#endif
...
```

```
ConsoleAppOld>msbuild ConsoleAppOld.sln /t:Restore,Build
ConsoleAppOld>type ConsoleAppOld\obj\Debug\ConsoleAppOld.Version.cs
...
[assembly: System.Reflection.AssemblyInformationalVersionAttribute("1.0.2-old+c24df8c31b")]
#if NETSTANDARD || NETFRAMEWORK || NETCOREAPP
[System.CodeDom.Compiler.GeneratedCode("Nerdbank.GitVersioning.Tasks","3.2.31.56335")]
#endif
...
```
