### PR TITLE
Use UtcTicks instead of Ticks to fix GitCommitDate 

### DIFF
--- a/src/Nerdbank.GitVersioning.Tasks/GetBuildVersion.cs
+++ b/src/Nerdbank.GitVersioning.Tasks/GetBuildVersion.cs
@@ -230,7 +230,7 @@
                 this.PrereleaseVersion = oracle.PrereleaseVersion;
                 this.GitCommitId = oracle.GitCommitId;
                 this.GitCommitIdShort = oracle.GitCommitIdShort;
-                this.GitCommitDateTicks = oracle.GitCommitDate != null ? oracle.GitCommitDate.Value.Ticks.ToString(CultureInfo.InvariantCulture) : null;
+                this.GitCommitDateTicks = oracle.GitCommitDate != null ? oracle.GitCommitDate.Value.UtcTicks.ToString(CultureInfo.InvariantCulture) : null;
                 this.GitVersionHeight = oracle.VersionHeight;
                 this.BuildMetadataFragment = oracle.BuildMetadataFragment;
                 this.CloudBuildNumber = oracle.CloudBuildNumberEnabled ? oracle.CloudBuildNumber : null;


### PR DESCRIPTION
The value for GitCommitDate is currently written as clock time ticks by AssemblyVersionInfo.cs which are then interpreted as UTC ticks when *.Version.cs gets executed. This leads to GitCommitDate containing clock time incorrectly declared as UTC time.