### PR TITLE
Add name of cloudbuild environment variable for TeamCity

### DIFF
--- a/doc/cloudbuild.md
+++ b/doc/cloudbuild.md
@@ -149,7 +149,7 @@ Check out [nerdbank-gitversioning on the GitHub Actions marketplace](https://git
 
 ### TeamCity
 TeamCity does not expose the build branch by default as an environment variable. This can be exposed by
-adding an environment variable with the value of `%teamcity.build.vcs.branch.<vcsid>%` where `<vcsid>` is
+adding an environment variable called BUILD_GIT_BRANCH with the value of `%teamcity.build.vcs.branch.<vcsid>%` where `<vcsid>` is
 the root id described on the TeamCity VCS roots page. Details on this variable can be found on the
 [TeamCity docs](https://confluence.jetbrains.com/display/TCD8/Predefined+Build+Parameters).
 


### PR DESCRIPTION
The TeamCity documentation didn't state what the name of the environment variable was supposed to be to get it working. I got the name from the following line: 

https://github.com/dotnet/Nerdbank.GitVersioning/blob/44e8bfc8dc6ae700509563b0bf1d9766b1188ed1/src/NerdBank.GitVersioning/CloudBuildServices/TeamCity.cs#L16