### PR TITLE
Allow TeamCity to provide tag refs

### DIFF
--- a/src/NerdBank.GitVersioning.Tests/BuildIntegrationTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/BuildIntegrationTests.cs
@@ -461,7 +461,9 @@ public class BuildIntegrationTests : RepoTestBase, IClassFixture<MSBuildFixture>
         {
             new object[] { CloudBuild.AppVeyor.SetItem("APPVEYOR_REPO_BRANCH", branchName) },
             new object[] { CloudBuild.VSTS.SetItem("BUILD_SOURCEBRANCH", $"refs/heads/{branchName}") },
+            new object[] { CloudBuild.VSTS.SetItem("BUILD_SOURCEBRANCH", $"refs/tags/{branchName}") },
             new object[] { CloudBuild.Teamcity.SetItem("BUILD_GIT_BRANCH", $"refs/heads/{branchName}") },
+            new object[] { CloudBuild.Teamcity.SetItem("BUILD_GIT_BRANCH", $"refs/tags/{branchName}") },
         };
     }
 
@@ -472,7 +474,11 @@ public class BuildIntegrationTests : RepoTestBase, IClassFixture<MSBuildFixture>
         var versionOptions = new VersionOptions
         {
             Version = SemanticVersion.Parse("1.0"),
-            PublicReleaseRefSpec = new string[] { "^refs/heads/release$" },
+            PublicReleaseRefSpec = new string[] 
+            { 
+                "^refs/heads/release$",
+                "^refs/tags/release$"
+            },
         };
         this.WriteVersionFile(versionOptions);
         this.InitializeSourceControl();

--- a/src/NerdBank.GitVersioning/CloudBuild.cs
+++ b/src/NerdBank.GitVersioning/CloudBuild.cs
@@ -43,5 +43,13 @@
                 value.StartsWith(prefix, StringComparison.Ordinal) ? value :
                 prefix + value;
         }
+
+        /// <summary>
+        /// Gets the specified string if it starts with a given prefix; otherwise null.
+        /// </summary>
+        /// <param name="value">The value to return.</param>
+        /// <param name="prefix">The prefix to check for.</param>
+        /// <returns><paramref name="value"/> if it starts with <paramref name="prefix"/>; otherwise <c>null</c>.</returns>
+        internal static string IfStartsWith(string value, string prefix) => value is object && value.StartsWith(prefix, StringComparison.Ordinal) ? value : null;
     }
 }

--- a/src/NerdBank.GitVersioning/CloudBuildServices/TeamCity.cs
+++ b/src/NerdBank.GitVersioning/CloudBuildServices/TeamCity.cs
@@ -13,9 +13,9 @@
     /// </remarks>
     internal class TeamCity : ICloudBuild
     {
-        public string BuildingBranch => CloudBuild.ShouldStartWith((BuildingRef?.StartsWith("refs/heads/") ?? false) ? BuildingRef : null, "refs/heads/");
+        public string BuildingBranch => CloudBuild.IfStartsWith(BuildingRef, "refs/heads/");
 
-        public string BuildingTag => (BuildingRef?.StartsWith("refs/tags/") ?? false) ? BuildingRef : null;
+        public string BuildingTag => CloudBuild.IfStartsWith(BuildingRef, "refs/tags/");
 
         public string GitCommitId => Environment.GetEnvironmentVariable("BUILD_VCS_NUMBER");
 

--- a/src/NerdBank.GitVersioning/CloudBuildServices/TeamCity.cs
+++ b/src/NerdBank.GitVersioning/CloudBuildServices/TeamCity.cs
@@ -13,15 +13,17 @@
     /// </remarks>
     internal class TeamCity : ICloudBuild
     {
-        public string BuildingBranch => CloudBuild.ShouldStartWith(Environment.GetEnvironmentVariable("BUILD_GIT_BRANCH"), "refs/heads/");
+        public string BuildingBranch => CloudBuild.ShouldStartWith((BuildingRef?.StartsWith("refs/heads/") ?? false) ? BuildingRef : null, "refs/heads/");
 
-        public string BuildingTag => null;
+        public string BuildingTag => (BuildingRef?.StartsWith("refs/tags/") ?? false) ? BuildingRef : null;
 
         public string GitCommitId => Environment.GetEnvironmentVariable("BUILD_VCS_NUMBER");
 
         public bool IsApplicable => this.GitCommitId != null;
 
         public bool IsPullRequest => false;
+
+        private static string BuildingRef => Environment.GetEnvironmentVariable("BUILD_GIT_BRANCH");
 
         public IReadOnlyDictionary<string, string>  SetCloudBuildNumber(string buildNumber, TextWriter stdout, TextWriter stderr)
         {

--- a/src/NerdBank.GitVersioning/CloudBuildServices/VisualStudioTeamServices.cs
+++ b/src/NerdBank.GitVersioning/CloudBuildServices/VisualStudioTeamServices.cs
@@ -15,9 +15,9 @@
     {
         public bool IsPullRequest => BuildingRef?.StartsWith("refs/pull/") ?? false;
 
-        public string BuildingTag => (BuildingRef?.StartsWith("refs/tags/") ?? false) ? BuildingRef : null;
+        public string BuildingTag => CloudBuild.IfStartsWith(BuildingRef, "refs/tags/");
 
-        public string BuildingBranch => (BuildingRef?.StartsWith("refs/heads/") ?? false) ? BuildingRef : null;
+        public string BuildingBranch => CloudBuild.IfStartsWith(BuildingRef, "refs/heads/");
 
         public string GitCommitId => null;
 


### PR DESCRIPTION
Since TeamCity can build tags as well, the TeamCity cloudbuild needs to understand when there comes a `refs/tags/tagname`. Otherwise it converts it to `refs/heads/refs/tags/tagname`, and makes the publicReleaseRefSpec check fail