### PR TITLE
Fix build integration tests in light of MSBuild 16.7

### DIFF
--- a/src/NerdBank.GitVersioning.Tests/NerdBank.GitVersioning.Tests.csproj
+++ b/src/NerdBank.GitVersioning.Tests/NerdBank.GitVersioning.Tests.csproj
@@ -34,6 +34,8 @@
     <PackageReference Include="Microsoft.Build" Version="15.1.548" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.1.548" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.Build.Locator" Version="1.2.2" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.2" />
+    <PackageReference Include="System.Numerics.Vectors" Version="4.4.0" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.9.0" />
     <PackageReference Include="Xunit.Combinatorial" Version="1.2.7" />
     <PackageReference Include="xunit" Version="2.4.1" />


### PR DESCRIPTION
This works around https://github.com/microsoft/MSBuildLocator/issues/95
