### PR TITLE
Perf: Cache JSON parse results while computing height

### DIFF
--- a/src/NerdBank.GitVersioning/GitExtensions.cs
+++ b/src/NerdBank.GitVersioning/GitExtensions.cs
@@ -984,6 +984,7 @@
         private class GitWalkTracker
         {
             private readonly Dictionary<ObjectId, VersionOptions> commitVersionCache = new Dictionary<ObjectId, VersionOptions>();
+            private readonly Dictionary<ObjectId, VersionOptions> blobVersionCache = new Dictionary<ObjectId, VersionOptions>();
             private readonly Dictionary<ObjectId, int> heights = new Dictionary<ObjectId, int>();
 
             internal GitWalkTracker(string repoRelativeDirectory)
@@ -1003,7 +1004,7 @@
                 {
                     try
                     {
-                        options = VersionFile.GetVersion(commit, this.RepoRelativeDirectory);
+                        options = VersionFile.GetVersion(commit, this.RepoRelativeDirectory, this.blobVersionCache);
                     }
                     catch (Exception ex)
                     {

--- a/src/NerdBank.GitVersioning/SemanticVersion.cs
+++ b/src/NerdBank.GitVersioning/SemanticVersion.cs
@@ -112,19 +112,19 @@
         /// <summary>
         /// Gets the version.
         /// </summary>
-        public Version Version { get; private set; }
+        public Version Version { get; }
 
         /// <summary>
         /// Gets an unstable tag (with the leading hyphen), if applicable.
         /// </summary>
         /// <value>A string with a leading hyphen or the empty string.</value>
-        public string Prerelease { get; private set; }
+        public string Prerelease { get; }
 
         /// <summary>
         /// Gets the build metadata (with the leading plus), if applicable.
         /// </summary>
         /// <value>A string with a leading plus or the empty string.</value>
-        public string BuildMetadata { get; private set; }
+        public string BuildMetadata { get; }
 
         /// <summary>
         /// Gets a value indicating whether this instance is the default "0.0" instance.

--- a/src/NerdBank.GitVersioning/VersionFile.cs
+++ b/src/NerdBank.GitVersioning/VersionFile.cs
@@ -58,6 +58,7 @@
                         result = TryReadVersionFile(new StreamReader(versionTxtBlob.GetContentStream()));
                         if (blobVersionCache is object)
                         {
+                            result?.Freeze();
                             blobVersionCache.Add(versionTxtBlob.Id, result);
                         }
                     }
@@ -94,6 +95,7 @@
 
                         if (blobVersionCache is object)
                         {
+                            result?.Freeze();
                             blobVersionCache.Add(versionJsonBlob.Id, result);
                         }
                     }
@@ -112,6 +114,11 @@
                                     {
                                         versionJsonContent = sr.ReadToEnd();
                                     }
+                                }
+
+                                if (result.IsFrozen)
+                                {
+                                    result = new VersionOptions(result);
                                 }
 
                                 JsonConvert.PopulateObject(versionJsonContent, result, VersionOptions.GetJsonSettings(repoRelativeBaseDirectory: searchDirectory));

--- a/src/NerdBank.GitVersioning/VersionOracle.cs
+++ b/src/NerdBank.GitVersioning/VersionOracle.cs
@@ -115,7 +115,7 @@
 
             this.CloudBuildNumberOptions = this.VersionOptions?.CloudBuild?.BuildNumberOrDefault ?? VersionOptions.CloudBuildNumberOptions.DefaultInstance;
 
-            if (!string.IsNullOrEmpty(this.BuildingRef) && this.VersionOptions?.PublicReleaseRefSpec?.Length > 0)
+            if (!string.IsNullOrEmpty(this.BuildingRef) && this.VersionOptions?.PublicReleaseRefSpec?.Count > 0)
             {
                 this.PublicRelease = this.VersionOptions.PublicReleaseRefSpec.Any(
                     expr => Regex.IsMatch(this.BuildingRef, expr));


### PR DESCRIPTION
Previous to this, we were re-parsing the same JSON content for every commit we encountered it in. Now we cache it based on the blob ID so (except in certain inherit cases) we never parse a given JSON content more than once while computing height.

As part of this caching I had to make sure that a cached `VersionOptions` instance would not be changed later, which is exactly what happens when `inherit: true`, so most of the diff is me making this type and all other types in the object tree freezable so it'll throw instead of allow corruption.