### PR TITLE
Add node.js bin scripts to nb-gv NPM package

### DIFF
--- a/src/nerdbank-gitversioning.npm/README.md
+++ b/src/nerdbank-gitversioning.npm/README.md
@@ -1,5 +1,4 @@
-Nerdbank.GitVersioning
-======================
+# nerdbank-gitversioning
 
 With this package, and a version.json file to express your version number
 checked into the root of your git repo:
@@ -12,6 +11,52 @@ checked into the root of your git repo:
 
 Your NPM packages and other builds can be automatically stamped with a
 version that precisely describes the git commit that built it.
+
+## CLI use
+
+Stamp your package.json file with the git-based version:
+
+```sh
+nbgv-setversion
+```
+
+Reset your package.json file with a version placeholder (suitable for checking in):
+
+```sh
+nbgv-setversion --reset
+```
+
+Or invoke the `nbgv` tool directly for many options:
+
+```sh
+nbgv -?
+```
+
+### Pack script
+
+A possible script to pack your NPM package:
+
+```sh
+yarn nbgv-setversion
+yarn pack
+yarn nbgv-setversion --reset
+```
+
+## Programmatic consumption
+
+```ts
+import * as nbgv from 'nerdbank-gitversioning'
+
+// Retrieve all sorts of version information. Print just one bit.
+const versionInfo = await nbgv.getVersion();
+console.log(versionInfo.npmPackageVersion);
+
+// Stamp the package.json file in the current directory with the computed version.
+await nbgv.setPackageVersion();
+
+// After packing, reset your package.json file to using a placeholder version number.
+await nbgv.resetPackageVersionPlaceholder();
+```
 
 See our [project README][GitHubREADME] for more information.
 

--- a/src/nerdbank-gitversioning.npm/package.json
+++ b/src/nerdbank-gitversioning.npm/package.json
@@ -7,6 +7,10 @@
     "email": "andrewarnott@gmail.com",
     "url": "http://blog.nerdbank.net/"
   },
+  "bin": {
+    "nbgv": "main.js",
+    "nbgv-setversion": "npmVersion.js"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/dotnet/Nerdbank.GitVersioning.git"

--- a/src/nerdbank-gitversioning.npm/ts/core.ts
+++ b/src/nerdbank-gitversioning.npm/ts/core.ts
@@ -1,0 +1,10 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+const nbgvPath = 'nbgv.cli';
+
+export function getNbgvCommand(dotnetCommand?: string): string {
+    var command = dotnetCommand || 'dotnet';
+    const nbgvDll = path.join(__dirname, nbgvPath, "tools", "netcoreapp2.1", "any", "nbgv.dll");
+    return `${command} "${nbgvDll}"`;
+}

--- a/src/nerdbank-gitversioning.npm/ts/index.ts
+++ b/src/nerdbank-gitversioning.npm/ts/index.ts
@@ -1,11 +1,8 @@
 'use strict';
 
-import * as fs from 'fs';
-import * as path from 'path';
 import * as camelCase from 'camel-case';
-import {execAsync} from './asyncprocess';
-
-const nbgvPath = 'nbgv.cli';
+import { execAsync } from './asyncprocess';
+import { getNbgvCommand } from './core';
 
 /**
  * The various aspects of a version that can be calculated.
@@ -43,9 +40,7 @@ export interface IGitVersion {
  */
 export async function getVersion(projectDirectory?: string, dotnetCommand?: string): Promise<IGitVersion> {
     projectDirectory = projectDirectory || '.';
-    var command = dotnetCommand || 'dotnet';
-    var getVersionScriptPath = path.join(__dirname, nbgvPath, "tools", "netcoreapp2.1", "any", "nbgv.dll");
-    var versionText = await execAsync(`${command} "${getVersionScriptPath}" get-version --format json`, { cwd: projectDirectory })
+    var versionText = await execAsync(`${getNbgvCommand(dotnetCommand)} get-version --format json`, { cwd: projectDirectory })
     if (versionText.stderr) {
         throw versionText.stderr;
     }
@@ -83,7 +78,7 @@ export async function setPackageVersion(packageDirectory?: string, srcDirectory?
  */
 export async function resetPackageVersionPlaceholder(srcDirectory?: string) {
     srcDirectory = srcDirectory || '.';
-    var result = await execAsync(`npm version 0.0.0-placeholder`, { cwd: srcDirectory });
+    var result = await execAsync(`npm version 0.0.0-placeholder --no-git-tag-version --allow-same-version`, { cwd: srcDirectory });
     if (result.stderr) {
         console.log(result.stderr);
     }

--- a/src/nerdbank-gitversioning.npm/ts/main.ts
+++ b/src/nerdbank-gitversioning.npm/ts/main.ts
@@ -1,14 +1,11 @@
-'use string';
+#!/usr/bin/env node
 
-import * as lib from './index'
+'use strict';
 
-async function printGitVersion() {
-    try {
-        console.log(await lib.getVersion());
-    } catch (err) {
-        console.log('Failed to get version:');
-        console.log(err);
-    }
-}
+import { getNbgvCommand } from "./core";
 
-printGitVersion();
+const { spawn } = require('child_process');
+const { argv, exit } = require('process');
+
+const cp = spawn(`${getNbgvCommand()} ${argv.slice(2).join(' ')}`, { shell: true, stdio: "inherit" })
+cp.once('exit', code => exit(code))

--- a/src/nerdbank-gitversioning.npm/ts/npmVersion.ts
+++ b/src/nerdbank-gitversioning.npm/ts/npmVersion.ts
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+
+import * as lib from './index'
+
+(async () => {
+    if (process.argv[2] === '--reset') {
+        await lib.resetPackageVersionPlaceholder();
+    } else {
+        await lib.setPackageVersion();
+    }
+})();


### PR DESCRIPTION
This adds `nbgv` and `nbgv-setversion` as NPM bin scripts. NPM projects that consume the `nerdbank-gitversioning` NPM package can now execute these commands like any other NPM script to get NB.GV functionality.