### PR TITLE
Github Actions: Use Environment File

### DIFF
--- a/src/NerdBank.GitVersioning/CloudBuildServices/GitHubActions.cs
+++ b/src/NerdBank.GitVersioning/CloudBuildServices/GitHubActions.cs
@@ -28,7 +28,7 @@
 
         public IReadOnlyDictionary<string, string> SetCloudBuildVariable(string name, string value, TextWriter stdout, TextWriter stderr)
         {
-            File.AppendAllText(EnvironmentFile, $"{name}={value}{Environment.NewLine}");
+            File.AppendAllText(EnvironmentFile, $"{Environment.NewLine}{name}={value}{Environment.NewLine}");
             return GetDictionaryFor(name, value);
         }
 

--- a/src/NerdBank.GitVersioning/CloudBuildServices/GitHubActions.cs
+++ b/src/NerdBank.GitVersioning/CloudBuildServices/GitHubActions.cs
@@ -19,6 +19,8 @@
 
         private static string BuildingRef => Environment.GetEnvironmentVariable("GITHUB_REF");
 
+        private static string EnvironmentFile => Environment.GetEnvironmentVariable("GITHUB_ENV");
+
         public IReadOnlyDictionary<string, string> SetCloudBuildNumber(string buildNumber, TextWriter stdout, TextWriter stderr)
         {
             return new Dictionary<string, string>();
@@ -26,7 +28,7 @@
 
         public IReadOnlyDictionary<string, string> SetCloudBuildVariable(string name, string value, TextWriter stdout, TextWriter stderr)
         {
-            (stdout ?? Console.Out).WriteLine($"##[set-env name={name};]{value}");
+            File.AppendAllText(EnvironmentFile, $"{name}={value}{Environment.NewLine}");
             return GetDictionaryFor(name, value);
         }
 


### PR DESCRIPTION
Recently, Github Actions [deprecated the set-env command in favor of using environment files](https://github.com/actions/toolkit/security/advisories/GHSA-mfwh-5m23-j46w).  Since then, I've been getting a lot of warnings about set-env that stem from its use here.   

This PR updates GithubActions.SetCloudBuildVariable to write to the environment file, rather than use the set-env command.   

