### PR TITLE
Enable tests on netcoreapp3.1

### DIFF
--- a/src/NerdBank.GitVersioning.Tests/BuildIntegrationTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/BuildIntegrationTests.cs
@@ -940,6 +940,7 @@ public class BuildIntegrationTests : RepoTestBase, IClassFixture<MSBuildFixture>
         Assert.Empty(result.LoggedEvents.OfType<BuildWarningEventArgs>());
     }
 
+#if !NETCORE
     /// <summary>
     /// Create a native resource .dll and verify that its version
     ///  information is set correctly.
@@ -962,6 +963,7 @@ public class BuildIntegrationTests : RepoTestBase, IClassFixture<MSBuildFixture>
         Assert.Equal("NerdBank", fileInfo.CompanyName);
         Assert.Equal($"Copyright (c) {DateTime.Now.Year}. All rights reserved.", fileInfo.LegalCopyright);
     }
+#endif
 
     private static Version GetExpectedAssemblyVersion(VersionOptions versionOptions, Version version)
     {

--- a/src/NerdBank.GitVersioning.Tests/BuildIntegrationTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/BuildIntegrationTests.cs
@@ -940,7 +940,7 @@ public class BuildIntegrationTests : RepoTestBase, IClassFixture<MSBuildFixture>
         Assert.Empty(result.LoggedEvents.OfType<BuildWarningEventArgs>());
     }
 
-#if !NETCORE
+#if !NETCOREAPP
     /// <summary>
     /// Create a native resource .dll and verify that its version
     ///  information is set correctly.

--- a/src/NerdBank.GitVersioning.Tests/BuildIntegrationTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/BuildIntegrationTests.cs
@@ -57,6 +57,10 @@ public class BuildIntegrationTests : RepoTestBase, IClassFixture<MSBuildFixture>
 
     private void Init()
     {
+#if !NET461
+        GitLoaderContext.RuntimePath = "./runtimes";
+#endif
+
         int seed = (int)DateTime.Now.Ticks;
         this.random = new Random(seed);
         this.Logger.WriteLine("Random seed: {0}", seed);

--- a/src/NerdBank.GitVersioning.Tests/NerdBank.GitVersioning.Tests.csproj
+++ b/src/NerdBank.GitVersioning.Tests/NerdBank.GitVersioning.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFrameworks>net461;netcoreapp3.1</TargetFrameworks>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <DebugType>full</DebugType>

--- a/src/NerdBank.GitVersioning.Tests/TestUtilities.cs
+++ b/src/NerdBank.GitVersioning.Tests/TestUtilities.cs
@@ -1,4 +1,6 @@
-﻿using SevenZipNET;
+﻿#if NET461
+using SevenZipNET;
+#endif
 using Validation;
 
 using System;
@@ -58,6 +60,7 @@ internal static class TestUtilities
 
     internal static ExpandedRepo ExtractRepoArchive(string repoArchiveName)
     {
+#if NET461
         string archiveFilePath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
         string expandedFolderPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
 
@@ -84,6 +87,9 @@ internal static class TestUtilities
                 File.Delete(archiveFilePath);
             }
         }
+#else
+        throw new PlatformNotSupportedException();
+#endif
     }
 
     internal class ExpandedRepo : IDisposable

--- a/src/Nerdbank.GitVersioning.Tasks/AssemblyVersionInfo.cs
+++ b/src/Nerdbank.GitVersioning.Tasks/AssemblyVersionInfo.cs
@@ -310,6 +310,10 @@
                 Directory.CreateDirectory(Path.GetDirectoryName(this.OutputFile));
                 Utilities.FileOperationWithRetry(() => File.WriteAllText(this.OutputFile, fileContent));
             }
+            else
+            {
+                this.Log.LogError("CodeDomProvider not available for language: {0}. No version info will be embedded into assembly.", this.CodeLanguage);
+            }
 
             return !this.Log.HasLoggedErrors;
         }

--- a/src/Nerdbank.GitVersioning.Tasks/GitLoaderContext.cs
+++ b/src/Nerdbank.GitVersioning.Tasks/GitLoaderContext.cs
@@ -11,7 +11,7 @@ using RuntimeEnvironment = Microsoft.DotNet.PlatformAbstractions.RuntimeEnvironm
 
 namespace Nerdbank.GitVersioning
 {
-    internal class GitLoaderContext : AssemblyLoadContext
+    public class GitLoaderContext : AssemblyLoadContext
     {
         public static readonly GitLoaderContext Instance = new GitLoaderContext();
 


### PR DESCRIPTION
I'm prototyping work related to #505. The managed Git implementation, at the moment, uses `Span<T>` and friends, and targets `netcoreapp3.1`.

I retargeted the project and tests to run on `netcoreapp3.1` and came across a couple of test failures, which this PR attempts to resolve:

- The `AssemblyVersionInfo` task throws no error when targeting a language which is not supported
- `RuntimePath` appears to be `./runtimes` instead of `../runtimes`
- SevenZipNET does not target `netcoreapp`, and is only used in a test which is skipped. I have methods which rely on SevenZipNET throw a `PlatformNotSupportException`. 