### PR TITLE
Support unit testing NB.GV on Ubuntu 20.04/.NET 3.1

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -137,7 +137,7 @@ stages:
         --name 'Nerdbank.GitVersioning'
         --descriptionUrl 'https://github.com/dotnet/Nerdbank.GitVersioning'
       displayName: Code sign
-      condition: and(succeeded(), eq(variables['System.TeamFoundationCollectionUri'], 'https://dev.azure.com/andrewarnott/'), ne(variables['Build.Reason'], 'PullRequest'))
+      condition: and(succeeded(), eq(variables['System.TeamFoundationCollectionUri'], 'https://dev.azure.com/andrewarnott/'), eq(variables['Agent.OS'], 'Windows_NT'), ne(variables['Build.Reason'], 'PullRequest'))
 
     - task: PublishBuildArtifacts@1
       inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,7 +35,8 @@ stages:
   - job: Windows
     pool: Hosted Windows 2019 with VS2019
     variables:
-    - group: dotnetfoundation code signing
+    - ${{ if eq(variables['System.TeamFoundationCollectionUri	'], 'https://dev.azure.com/andrewarnott/') }}:
+      - group: dotnetfoundation code signing
     steps:
     - checkout: self
       clean: true
@@ -125,7 +126,7 @@ stages:
         --name 'Nerdbank.GitVersioning'
         --descriptionUrl 'https://github.com/dotnet/Nerdbank.GitVersioning'
       displayName: Code sign
-      condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+      condition: and(succeeded(), eq(variables['System.TeamFoundationCollectionUri'], 'https://dev.azure.com/andrewarnott/'), ne(variables['Build.Reason'], 'PullRequest'))
 
     - task: PublishBuildArtifacts@1
       inputs:
@@ -148,23 +149,23 @@ stages:
         nuGetFeedType: internal
         publishVstsFeed: OSS/PublicCI
         allowPackageConflicts: true
-      condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+      condition: and(succeeded(), eq(variables['System.TeamFoundationCollectionUri'], 'https://dev.azure.com/andrewarnott/'), ne(variables['Build.Reason'], 'PullRequest'))
 
     - pwsh: Set-Content -Path "$(Agent.TempDirectory)/.npmrc" -Value "registry=https://pkgs.dev.azure.com/andrewarnott/OSS/_packaging/PublicCI/npm/registry/`nalways-auth=true"
       displayName: Prepare to push to PublicCI
-      condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+      condition: and(succeeded(), eq(variables['System.TeamFoundationCollectionUri'], 'https://dev.azure.com/andrewarnott/'), ne(variables['Build.Reason'], 'PullRequest'))
     - task: npmAuthenticate@0
       displayName: Authenticate to PublicCI
       inputs:
         workingFile: $(Agent.TempDirectory)/.npmrc
-      condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+      condition: and(succeeded(), eq(variables['System.TeamFoundationCollectionUri'], 'https://dev.azure.com/andrewarnott/'), ne(variables['Build.Reason'], 'PullRequest'))
     - pwsh: |
         $tgz = (Get-ChildItem "$(Build.ArtifactStagingDirectory)/deployables/*.tgz")[0].FullName
         Write-Host "Will publish $tgz"
         npm publish $tgz
       workingDirectory: $(Agent.TempDirectory)
       displayName: npm publish to PublicCI feed
-      condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+      condition: and(succeeded(), eq(variables['System.TeamFoundationCollectionUri'], 'https://dev.azure.com/andrewarnott/'), ne(variables['Build.Reason'], 'PullRequest'))
 
 - stage: Test
   jobs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,11 +32,18 @@ variables:
 stages:
 - stage: Build
   jobs:
-  - job: Windows
-    pool: Hosted Windows 2019 with VS2019
+  - job: Build
+    strategy:
+      matrix:
+        linux:
+          imageName: 'ubuntu-20.04'
+        windows:
+          imageName: 'windows-2019'
     variables:
     - ${{ if eq(variables['System.TeamFoundationCollectionUri	'], 'https://dev.azure.com/andrewarnott/') }}:
       - group: dotnetfoundation code signing
+    pool:
+      vmImage: $(imageName)
     steps:
     - checkout: self
       clean: true
@@ -54,9 +61,9 @@ stages:
     - script: dotnet --info
       displayName: Show dotnet SDK info
 
-    - script: |
+    - pwsh: |
         dotnet tool install --tool-path . nbgv
-        .\nbgv cloud -a
+        ./nbgv cloud -a
       displayName: Set build number
 
     - task: DotNetCoreCLI@2
@@ -80,16 +87,16 @@ stages:
       displayName: Build NuGet package and tests
       workingDirectory: src
 
-    - script: dotnet publish -c $(BuildConfiguration) -o ..\nerdbank-gitversioning.npm\out\nbgv.cli\tools\netcoreapp2.1\any /bl:"$(Build.ArtifactStagingDirectory)/build_logs/nbgv_publish.binlog"
+    - script: dotnet publish -c $(BuildConfiguration) -o ../nerdbank-gitversioning.npm/out/nbgv.cli/tools/netcoreapp2.1/any /bl:"$(Build.ArtifactStagingDirectory)/build_logs/nbgv_publish.binlog"
       displayName: Publish nbgv tool
-      workingDirectory: src\nbgv
+      workingDirectory: src/nbgv
 
     - task: gulp@0
       displayName: Build nerdbank-gitversioning NPM package
       inputs:
-        gulpfile: src\nerdbank-gitversioning.npm\gulpfile.js
+        gulpfile: src/nerdbank-gitversioning.npm/gulpfile.js
 
-    - script: dotnet test Nerdbank.GitVersioning.Tests --no-build -c $(BuildConfiguration) --filter "TestCategory!=FailsOnAzurePipelines" --logger "trx;LogFileName=$(Build.ArtifactStagingDirectory)\TestLogs\TestResults.trx"
+    - script: dotnet test NerdBank.GitVersioning.Tests --no-build -c $(BuildConfiguration) --filter "TestCategory!=FailsOnAzurePipelines" --logger "trx;LogFileName=$(Build.ArtifactStagingDirectory)/TestLogs/TestResults.trx"
       displayName: Run tests
       workingDirectory: src
 
@@ -98,7 +105,7 @@ stages:
       inputs:
         testResultsFormat: VSTest
         testResultsFiles: '*.trx'
-        searchFolder: $(Build.ArtifactStagingDirectory)\TestLogs
+        searchFolder: $(Build.ArtifactStagingDirectory)/TestLogs
         buildPlatform: $(BuildPlatform)
         buildConfiguration: $(BuildConfiguration)
       condition: always()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -68,12 +68,12 @@ stages:
         nugetConfigPath: src/nuget.config
         workingDirectory: src
 
-    - task: geeklearningio.gl-vsts-tasks-yarn.yarn-installer-task.YarnInstaller@2
+    - task: YarnInstaller@3
       displayName: 'Use Yarn 1.x'
-    - task: geeklearningio.gl-vsts-tasks-yarn.yarn-task.Yarn@2
+    - task: Yarn@3
       displayName: 'Yarn install'
       inputs:
-        ProjectDirectory: 'src/nerdbank-gitversioning.npm'
+        projectDirectory: 'src/nerdbank-gitversioning.npm'
 
     - script: dotnet build -c $(BuildConfiguration) --no-restore /t:build,pack /bl:"$(Build.ArtifactStagingDirectory)/build_logs/msbuild.binlog"
       displayName: Build NuGet package and tests

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,8 +39,10 @@ stages:
       matrix:
         linux:
           imageName: 'ubuntu-20.04'
+          testModifier: -f netcoreapp3.1
         windows:
           imageName: 'windows-2019'
+          testModifier:
     variables:
     - ${{ if eq(variables['System.TeamFoundationCollectionUri	'], 'https://dev.azure.com/andrewarnott/') }}:
       - group: dotnetfoundation code signing
@@ -98,7 +100,7 @@ stages:
       inputs:
         gulpfile: src/nerdbank-gitversioning.npm/gulpfile.js
 
-    - script: dotnet test NerdBank.GitVersioning.Tests --no-build -c $(BuildConfiguration) --filter "TestCategory!=FailsOnAzurePipelines" --logger "trx;LogFileName=$(Build.ArtifactStagingDirectory)/TestLogs/TestResults.trx"
+    - script: dotnet test NerdBank.GitVersioning.Tests --no-build $(testModifier) -c $(BuildConfiguration) --filter "TestCategory!=FailsOnAzurePipelines" --logger "trx;LogFileName=$(Build.ArtifactStagingDirectory)/TestLogs/TestResults.trx"
       displayName: Run tests
       workingDirectory: src
 
@@ -144,7 +146,7 @@ stages:
         ArtifactType: Container
       displayName: Publish deployables artifacts
       # Only deploy when from a single build in the build matrix
-      condition: and(succeeded(), eq(variables['imageName'], 'windows-2019'))
+      condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
 
     - task: PublishBuildArtifacts@1
       inputs:
@@ -161,23 +163,23 @@ stages:
         nuGetFeedType: internal
         publishVstsFeed: OSS/PublicCI
         allowPackageConflicts: true
-      condition: and(succeeded(), eq(variables['imageName'], 'windows-2019'), eq(variables['System.TeamFoundationCollectionUri'], 'https://dev.azure.com/andrewarnott/'), ne(variables['Build.Reason'], 'PullRequest'))
+      condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'), eq(variables['System.TeamFoundationCollectionUri'], 'https://dev.azure.com/andrewarnott/'), ne(variables['Build.Reason'], 'PullRequest'))
 
     - pwsh: Set-Content -Path "$(Agent.TempDirectory)/.npmrc" -Value "registry=https://pkgs.dev.azure.com/andrewarnott/OSS/_packaging/PublicCI/npm/registry/`nalways-auth=true"
       displayName: Prepare to push to PublicCI
-      condition: and(succeeded(), eq(variables['imageName'], 'windows-2019'), eq(variables['System.TeamFoundationCollectionUri'], 'https://dev.azure.com/andrewarnott/'), ne(variables['Build.Reason'], 'PullRequest'))
+      condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'), eq(variables['System.TeamFoundationCollectionUri'], 'https://dev.azure.com/andrewarnott/'), ne(variables['Build.Reason'], 'PullRequest'))
     - task: npmAuthenticate@0
       displayName: Authenticate to PublicCI
       inputs:
         workingFile: $(Agent.TempDirectory)/.npmrc
-      condition: and(succeeded(), eq(variables['imageName'], 'windows-2019'), eq(variables['System.TeamFoundationCollectionUri'], 'https://dev.azure.com/andrewarnott/'), ne(variables['Build.Reason'], 'PullRequest'))
+      condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'), eq(variables['System.TeamFoundationCollectionUri'], 'https://dev.azure.com/andrewarnott/'), ne(variables['Build.Reason'], 'PullRequest'))
     - pwsh: |
         $tgz = (Get-ChildItem "$(Build.ArtifactStagingDirectory)/deployables/*.tgz")[0].FullName
         Write-Host "Will publish $tgz"
         npm publish $tgz
       workingDirectory: $(Agent.TempDirectory)
       displayName: npm publish to PublicCI feed
-      condition: and(succeeded(), eq(variables['imageName'], 'windows-2019'), eq(variables['System.TeamFoundationCollectionUri'], 'https://dev.azure.com/andrewarnott/'), ne(variables['Build.Reason'], 'PullRequest'))
+      condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'), eq(variables['System.TeamFoundationCollectionUri'], 'https://dev.azure.com/andrewarnott/'), ne(variables['Build.Reason'], 'PullRequest'))
 
 - stage: Test
   jobs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -141,6 +141,9 @@ stages:
         ArtifactName: deployables
         ArtifactType: Container
       displayName: Publish deployables artifacts
+      # Only deploy when from a single build in the build matrix
+      condition: and(succeeded(), eq(variables['imageName'], 'windows-2019'))
+
     - task: PublishBuildArtifacts@1
       inputs:
         PathtoPublish: $(Build.ArtifactStagingDirectory)/build_logs
@@ -156,23 +159,23 @@ stages:
         nuGetFeedType: internal
         publishVstsFeed: OSS/PublicCI
         allowPackageConflicts: true
-      condition: and(succeeded(), eq(variables['System.TeamFoundationCollectionUri'], 'https://dev.azure.com/andrewarnott/'), ne(variables['Build.Reason'], 'PullRequest'))
+      condition: and(succeeded(), eq(variables['imageName'], 'windows-2019'), eq(variables['System.TeamFoundationCollectionUri'], 'https://dev.azure.com/andrewarnott/'), ne(variables['Build.Reason'], 'PullRequest'))
 
     - pwsh: Set-Content -Path "$(Agent.TempDirectory)/.npmrc" -Value "registry=https://pkgs.dev.azure.com/andrewarnott/OSS/_packaging/PublicCI/npm/registry/`nalways-auth=true"
       displayName: Prepare to push to PublicCI
-      condition: and(succeeded(), eq(variables['System.TeamFoundationCollectionUri'], 'https://dev.azure.com/andrewarnott/'), ne(variables['Build.Reason'], 'PullRequest'))
+      condition: and(succeeded(), eq(variables['imageName'], 'windows-2019'), eq(variables['System.TeamFoundationCollectionUri'], 'https://dev.azure.com/andrewarnott/'), ne(variables['Build.Reason'], 'PullRequest'))
     - task: npmAuthenticate@0
       displayName: Authenticate to PublicCI
       inputs:
         workingFile: $(Agent.TempDirectory)/.npmrc
-      condition: and(succeeded(), eq(variables['System.TeamFoundationCollectionUri'], 'https://dev.azure.com/andrewarnott/'), ne(variables['Build.Reason'], 'PullRequest'))
+      condition: and(succeeded(), eq(variables['imageName'], 'windows-2019'), eq(variables['System.TeamFoundationCollectionUri'], 'https://dev.azure.com/andrewarnott/'), ne(variables['Build.Reason'], 'PullRequest'))
     - pwsh: |
         $tgz = (Get-ChildItem "$(Build.ArtifactStagingDirectory)/deployables/*.tgz")[0].FullName
         Write-Host "Will publish $tgz"
         npm publish $tgz
       workingDirectory: $(Agent.TempDirectory)
       displayName: npm publish to PublicCI feed
-      condition: and(succeeded(), eq(variables['System.TeamFoundationCollectionUri'], 'https://dev.azure.com/andrewarnott/'), ne(variables['Build.Reason'], 'PullRequest'))
+      condition: and(succeeded(), eq(variables['imageName'], 'windows-2019'), eq(variables['System.TeamFoundationCollectionUri'], 'https://dev.azure.com/andrewarnott/'), ne(variables['Build.Reason'], 'PullRequest'))
 
 - stage: Test
   jobs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,11 +14,13 @@ resources:
   containers:
   - container: xenial
     image: andrewarnott/linux-buildagent
-  - container: bionic
+  - container: bionic-2.1
     image: microsoft/dotnet:2.1-sdk-bionic
-  - container: bionic-3.0
-    image: mcr.microsoft.com/dotnet/core/sdk:3.0-bionic
-  - container: disco
+  - container: bionic
+    image: mcr.microsoft.com/dotnet/core/sdk:3.1-bionic
+  - container: focal
+    image: mcr.microsoft.com/dotnet/core/sdk:3.1-focal
+  - container: disco-3.0
     image: mcr.microsoft.com/dotnet/core/sdk:3.0-disco
   - container: archlinux
     image: andrewarnott/archlinux
@@ -188,6 +190,13 @@ stages:
       displayName: Install git
     - template: azure-pipelines/xplattest-pipeline.yml
 
+  - job: Ubuntu_Bionic_2_1
+    pool:
+      vmImage: Ubuntu 16.04 # not a bug. we always use this pool, but use containers for the specific version
+    container: bionic-2.1
+    steps:
+    - template: azure-pipelines/xplattest-pipeline.yml
+
   - job: Ubuntu_Bionic
     pool:
       vmImage: Ubuntu 16.04 # not a bug. we always use this pool, but use containers for the specific version
@@ -195,17 +204,17 @@ stages:
     steps:
     - template: azure-pipelines/xplattest-pipeline.yml
 
-  - job: Ubuntu_Bionic_3_0
+  - job: Ubuntu_Focal
     pool:
       vmImage: Ubuntu 16.04 # not a bug. we always use this pool, but use containers for the specific version
-    container: bionic-3.0
+    container: focal
     steps:
     - template: azure-pipelines/xplattest-pipeline.yml
 
-  - job: Ubuntu_Disco
+  - job: Ubuntu_Disco_3_0
     pool:
       vmImage: Ubuntu 16.04 # not a bug. we always use this pool, but use containers for the specific version
-    container: disco
+    container: disco-3.0
     steps:
     - template: azure-pipelines/xplattest-pipeline.yml
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,7 +44,7 @@ stages:
           imageName: 'windows-2019'
           testModifier:
     variables:
-    - ${{ if eq(variables['System.TeamFoundationCollectionUri	'], 'https://dev.azure.com/andrewarnott/') }}:
+    - ${{ if eq(variables['System.TeamFoundationCollectionUri'], 'https://dev.azure.com/andrewarnott/') }}:
       - group: dotnetfoundation code signing
     pool:
       vmImage: $(imageName)

--- a/src/NerdBank.GitVersioning.Tests/BuildIntegrationTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/BuildIntegrationTests.cs
@@ -742,7 +742,9 @@ public class BuildIntegrationTests : RepoTestBase, IClassFixture<MSBuildFixture>
         }
     }
 
-    [Theory]
+    // This test builds projects using 'classic' MSBuild projects, which target net45.
+    // This is not supported on Linux.
+    [WindowsTheory]
     [PairwiseData]
     public async Task AssemblyInfo(bool isVB, bool includeNonVersionAttributes, bool gitRepo, bool isPrerelease, bool isPublicRelease)
     {

--- a/src/NerdBank.GitVersioning.Tests/BuildIntegrationTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/BuildIntegrationTests.cs
@@ -844,7 +844,11 @@ public class BuildIntegrationTests : RepoTestBase, IClassFixture<MSBuildFixture>
 
         this.WriteVersionFile();
         var result = await this.BuildAsync(Targets.GenerateAssemblyVersionInfo, logVerbosity: LoggerVerbosity.Minimal);
-        string versionCsContent = File.ReadAllText(Path.Combine(this.projectDirectory, result.BuildResult.ProjectStateAfterBuild.GetPropertyValue("VersionSourceFile")));
+        string versionCsContent = File.ReadAllText(
+            Path.GetFullPath(
+                Path.Combine(
+                    this.projectDirectory,
+                    result.BuildResult.ProjectStateAfterBuild.GetPropertyValue("VersionSourceFile"))));
         this.Logger.WriteLine(versionCsContent);
 
         var sourceFile = CSharpSyntaxTree.ParseText(versionCsContent);

--- a/src/NerdBank.GitVersioning.Tests/BuildIntegrationTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/BuildIntegrationTests.cs
@@ -1152,7 +1152,7 @@ public class BuildIntegrationTests : RepoTestBase, IClassFixture<MSBuildFixture>
     private void MakeItAVBProject()
     {
         var csharpImport = this.testProject.Imports.Single(i => i.Project.Contains("CSharp"));
-        csharpImport.Project = @"$(MSBuildToolsPath)\Microsoft.VisualBasic.targets";
+        csharpImport.Project = "$(MSBuildToolsPath)/Microsoft.VisualBasic.targets";
         var isVbProperty = this.testProject.Properties.Single(p => p.Name == "IsVB");
         isVbProperty.Value = "true";
     }

--- a/src/NerdBank.GitVersioning.Tests/FilterPathTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/FilterPathTests.cs
@@ -14,20 +14,26 @@ public class FilterPathTests
     [InlineData("../../some/dir/here", "foo/multi/wow", "foo/some/dir/here")]
     [InlineData("relativepath.txt", "foo", "foo/relativepath.txt")]
     [InlineData("./relativepath.txt", "foo", "foo/relativepath.txt")]
-    [InlineData("./dir\\hi/relativepath.txt", "foo", "foo/dir/hi/relativepath.txt")]
-    [InlineData(".\\relativepath.txt", "foo", "foo/relativepath.txt")]
     [InlineData(":^relativepath.txt", "foo", "foo/relativepath.txt")]
     [InlineData(":!relativepath.txt", "foo", "foo/relativepath.txt")]
     [InlineData(":!/absolutepath.txt", "foo", "absolutepath.txt")]
-    [InlineData(":!\\absolutepath.txt", "foo", "absolutepath.txt")]
     [InlineData("../bar/relativepath.txt", "foo", "bar/relativepath.txt")]
     [InlineData("/", "foo", "")]
     [InlineData("/absolute/file.txt", "foo", "absolute/file.txt")]
     [InlineData(":/", "foo", "")]
     [InlineData(":/absolutepath.txt", "foo", "absolutepath.txt")]
     [InlineData(":/bar/absolutepath.txt", "foo", "bar/absolutepath.txt")]
-    [InlineData(":\\bar\\absolutepath.txt", "foo", "bar/absolutepath.txt")]
     public void CanBeParsedToRepoRelativePath(string pathSpec, string relativeTo, string expected)
+    {
+        Assert.Equal(expected, new FilterPath(pathSpec, relativeTo).RepoRelativePath);
+    }
+
+    [WindowsTheory]
+    [InlineData("./dir\\hi/relativepath.txt", "foo", "foo/dir/hi/relativepath.txt")]
+    [InlineData(".\\relativepath.txt", "foo", "foo/relativepath.txt")]
+    [InlineData(":!\\absolutepath.txt", "foo", "absolutepath.txt")]
+    [InlineData(":\\bar\\absolutepath.txt", "foo", "bar/absolutepath.txt")]
+    public void CanBeParsedToRepoRelativePath_WindowsOnly(string pathSpec, string relativeTo, string expected)
     {
         Assert.Equal(expected, new FilterPath(pathSpec, relativeTo).RepoRelativePath);
     }

--- a/src/NerdBank.GitVersioning.Tests/GitExtensionsTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/GitExtensionsTests.cs
@@ -529,10 +529,10 @@ public class GitExtensionsTests : RepoTestBase
     [Fact]
     public void GetIdAsVersion_ReadsMajorMinorFromVersionTxtInSubdirectory()
     {
-        this.WriteVersionFile("4.8", relativeDirectory: @"foo\bar");
+        this.WriteVersionFile("4.8", relativeDirectory: "foo/bar");
         var firstCommit = this.Repo.Commits.First();
 
-        Version v1 = firstCommit.GetIdAsVersion(@"foo\bar");
+        Version v1 = firstCommit.GetIdAsVersion("foo/bar");
         Assert.Equal(4, v1.Major);
         Assert.Equal(8, v1.Minor);
     }

--- a/src/NerdBank.GitVersioning.Tests/LibGit2Loader.cs
+++ b/src/NerdBank.GitVersioning.Tests/LibGit2Loader.cs
@@ -1,0 +1,80 @@
+#if NETCOREAPP
+using System;
+using System.IO;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using LibGit2Sharp;
+using Nerdbank.GitVersioning;
+using RuntimeEnvironment = Microsoft.DotNet.PlatformAbstractions.RuntimeEnvironment;
+
+public static class LibGit2Loader
+{
+    public static string RuntimePath = "./runtimes";
+
+    static LibGit2Loader()
+    {
+        NativeLibrary.SetDllImportResolver(typeof(Repository).Assembly, ImportResolver);
+    }
+
+    public static void EnsureRegistered()
+    {
+        // No-op, only here to ensure the static constructor is triggered
+    }
+
+    private static IntPtr ImportResolver(string libraryName, Assembly assembly, DllImportSearchPath? searchPath)
+    {
+        IntPtr handle = IntPtr.Zero;
+
+        if (libraryName.StartsWith("git2-", StringComparison.Ordinal) ||
+            libraryName.StartsWith("libgit2-", StringComparison.Ordinal))
+        {
+            var directory = GetNativeLibraryDirectory();
+            var extension = GetNativeLibraryExtension();
+
+            if (!libraryName.EndsWith(extension, StringComparison.Ordinal))
+            {
+                libraryName += extension;
+            }
+
+            var nativeLibraryPath = Path.Combine(directory, libraryName);
+            if (!File.Exists(nativeLibraryPath))
+            {
+                nativeLibraryPath = Path.Combine(directory, "lib" + libraryName);
+            }
+
+            if (!NativeLibrary.TryLoad(nativeLibraryPath, assembly, DllImportSearchPath.System32, out handle))
+            {
+                throw new NotImplementedException($"No support for loading {libraryName} at {nativeLibraryPath}");
+            }
+        }
+
+        return handle;
+    }
+
+    private static string GetNativeLibraryDirectory()
+    {
+        var dir = Path.GetDirectoryName(typeof(Repository).Assembly.Location);
+        return Path.Combine(dir, RuntimePath, RuntimeIdMap.GetNativeLibraryDirectoryName(RuntimeEnvironment.GetRuntimeIdentifier()), "native");
+    }
+
+    private static string GetNativeLibraryExtension()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return ".dll";
+        }
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            return ".dylib";
+        }
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        {
+            return ".so";
+        }
+
+        throw new PlatformNotSupportedException();
+    }
+}
+#endif

--- a/src/NerdBank.GitVersioning.Tests/NerdBank.GitVersioning.Tests.csproj
+++ b/src/NerdBank.GitVersioning.Tests/NerdBank.GitVersioning.Tests.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
-    <TargetFrameworks Condition="'$(MSBuildRuntimeType)' == 'Full'">$(TargetFrameworks);net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net461</TargetFrameworks>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <DebugType>full</DebugType>
@@ -47,8 +46,5 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.12" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
-    <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
   </ItemGroup>
 </Project>

--- a/src/NerdBank.GitVersioning.Tests/NerdBank.GitVersioning.Tests.csproj
+++ b/src/NerdBank.GitVersioning.Tests/NerdBank.GitVersioning.Tests.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(MSBuildRuntimeType)' == 'Full'">$(TargetFrameworks);net461</TargetFrameworks>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <DebugType>full</DebugType>

--- a/src/NerdBank.GitVersioning.Tests/RepoTestBase.cs
+++ b/src/NerdBank.GitVersioning.Tests/RepoTestBase.cs
@@ -1,10 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using LibGit2Sharp;
 using Nerdbank.GitVersioning;
 using Validation;
@@ -16,6 +12,10 @@ public abstract class RepoTestBase : IDisposable
 
     public RepoTestBase(ITestOutputHelper logger)
     {
+#if NETCOREAPP
+        LibGit2Loader.EnsureRegistered();
+#endif
+
         Requires.NotNull(logger, nameof(logger));
 
         this.Logger = logger;

--- a/src/NerdBank.GitVersioning.Tests/VersionFileTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/VersionFileTests.cs
@@ -515,20 +515,20 @@ public class VersionFileTests : RepoTestBase
                 Inherit = true,
                 VersionHeightOffset = 1,
             },
-            @"foo\bar");
+            "foo/bar");
         this.WriteVersionFile(
             level2NoInherit = new VersionOptions
             {
                 Version = SemanticVersion.Parse("10.1"),
             },
-            @"noInherit");
+            "noInherit");
         this.WriteVersionFile(
             level2InheritButResetVersion = new VersionOptions
             {
                 Inherit = true,
                 Version = SemanticVersion.Parse("8.2"),
             },
-            @"inheritWithVersion");
+            "inheritWithVersion");
 
         Repository operatingRepo = this.Repo;
         if (bareRepo)
@@ -550,7 +550,7 @@ public class VersionFileTests : RepoTestBase
             Assert.Equal(level2.AssemblyVersion.Precision, level2Options.AssemblyVersion.Precision);
             Assert.True(level2Options.Inherit);
 
-            var level3Options = GetOption(@"foo\bar");
+            var level3Options = GetOption("foo/bar");
             Assert.Equal(level1.Version.Version.Major, level3Options.Version.Version.Major);
             Assert.Equal(level1.Version.Version.Minor, level3Options.Version.Version.Minor);
             Assert.Equal(level2.AssemblyVersion.Precision, level3Options.AssemblyVersion.Precision);
@@ -575,7 +575,7 @@ public class VersionFileTests : RepoTestBase
                 // even though the inheriting files were introduced in successive commits.
                 Assert.Equal(totalCommits, operatingRepo.GetVersionHeight());
                 Assert.Equal(totalCommits, operatingRepo.GetVersionHeight("foo"));
-                Assert.Equal(totalCommits, operatingRepo.GetVersionHeight(@"foo\bar"));
+                Assert.Equal(totalCommits, operatingRepo.GetVersionHeight("foo/bar"));
 
                 // These either don't inherit, or inherit but reset versions, so the commits were reset.
                 Assert.Equal(2, operatingRepo.GetVersionHeight("noInherit"));

--- a/src/NerdBank.GitVersioning.Tests/VersionOracleTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/VersionOracleTests.cs
@@ -19,8 +19,8 @@ public class VersionOracleTests : RepoTestBase
     [Fact]
     public void NotRepo()
     {
-        // Seems safe to assume the system directory is not a repository.
-        var oracle = VersionOracle.Create(Environment.SystemDirectory);
+        // Seems safe to assume a temporary path is not a Git directory.
+        var oracle = VersionOracle.Create(Path.GetTempPath());
         Assert.Equal(0, oracle.VersionHeight);
     }
 

--- a/src/NerdBank.GitVersioning.Tests/WindowsTheoryAttribute.cs
+++ b/src/NerdBank.GitVersioning.Tests/WindowsTheoryAttribute.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using Xunit;
+
+public class WindowsTheoryAttribute : TheoryAttribute
+{
+    public override string Skip
+    {
+        get
+        {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return "This test runs on Windows only";
+            }
+
+            return null;
+        }
+        set
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/src/Nerdbank.GitVersioning.Tasks/RuntimeIdMap.cs
+++ b/src/Nerdbank.GitVersioning.Tasks/RuntimeIdMap.cs
@@ -7,7 +7,7 @@ using System.Diagnostics;
 
 namespace Nerdbank.GitVersioning
 {
-    internal static class RuntimeIdMap
+    public static class RuntimeIdMap
     {
         // This functionality needs to be provided as .NET Core API.
         // Releated issues:
@@ -256,6 +256,10 @@ namespace Nerdbank.GitVersioning
             "ubuntu.19.04-x64",
             "ubuntu.19.10-arm64",
             "ubuntu.19.10-x64",
+            "ubuntu.20.04-arm64",
+            "ubuntu.20.04-x64",
+            "ubuntu.20.10-arm64",
+            "ubuntu.20.10-x64",
             "win-x64",
             "win-x64-aot",
             "win-x86",
@@ -371,6 +375,10 @@ namespace Nerdbank.GitVersioning
             "linux-x64",
             "ubuntu.16.04-arm64",
             "linux-x64",
+            "debian-arm64",
+            "ubuntu.18.04-x64",
+            "debian-arm64",
+            "ubuntu.18.04-x64",
             "debian-arm64",
             "ubuntu.18.04-x64",
             "debian-arm64",

--- a/src/Nerdbank.GitVersioning.Tasks/build/Nerdbank.GitVersioning.targets
+++ b/src/Nerdbank.GitVersioning.Tasks/build/Nerdbank.GitVersioning.targets
@@ -138,7 +138,7 @@
 
   <Target Name="GenerateAssemblyVersionInfo" DependsOnTargets="GetBuildVersion" Condition=" '$(GenerateAssemblyVersionInfo)' != 'false' ">
     <PropertyGroup>
-      <VersionSourceFile>$(IntermediateOutputPath)\$(AssemblyName).Version$(DefaultLanguageSourceExtension)</VersionSourceFile>
+      <VersionSourceFile>$([MSBuild]::NormalizePath('$(IntermediateOutputPath)', '$(AssemblyName).Version$(DefaultLanguageSourceExtension)'))</VersionSourceFile>
       <NewVersionSourceFile>$(VersionSourceFile).new</NewVersionSourceFile>
       <UltimateResourceFallbackLocation Condition=" '$(DevDivProjectSubType)' != 'portable' ">UltimateResourceFallbackLocation.MainAssembly</UltimateResourceFallbackLocation>
     </PropertyGroup>
@@ -181,7 +181,7 @@
 
   <Target Name="GenerateNativeVersionInfo" DependsOnTargets="GetBuildVersion" Condition=" '$(Language)'=='C++' and '$(GenerateAssemblyVersionInfo)' != 'false' ">
     <PropertyGroup>
-      <VersionSourceFile>$(IntermediateOutputPath)\$(AssemblyName).Version.rc</VersionSourceFile>
+      <VersionSourceFile>$([MSBuild]::NormalizePath('$(IntermediateOutputPath)', '$(AssemblyName).Version.rc'))</VersionSourceFile>
       <NewVersionSourceFile>$(VersionSourceFile).new</NewVersionSourceFile>
     </PropertyGroup>
     <MakeDir Directories="$(IntermediatePath)"/>


### PR DESCRIPTION
I'm attempting to get `dotnet test` for the NerdBank.GitVersioning solution itself to work on Ubuntu 20.04 + .NET Core 3.1, since I want to run the unit tests for #521 locally.

Loading LibGit2Sharp fails because:

1. There's no version of LibGit2Sharp which supports Ubuntu 20.04
2. NerdBank.GitVersioning works around this by means of `GitLoaderContext`, but the unit tests do not execute within the scope of the `GitLoaderContext`.

I didn't see a straightforward way to replicate the `ContextAwareTask` approach to unit tests, so I used `NativeLibrary.SetDllImportResolver` instead.

PS - `NativeLibrary` is available starting with .NET Core 3.0, so if you're fine having nbgv target at least .NET Core 3.0, we can get rid of the `GitLoaderContext`/`ContextAwareTask` and use the `NativeLibrary.SetDllImportResolver` approach instead.