### PR TITLE
Add VS Code support

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+  "recommendations": [
+    "formulahendry.dotnet-test-explorer",
+    "ms-dotnettools.csharp",
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "dotnet-test-explorer.testProjectPath": "src/NerdBank.GitVersioning.Tests/NerdBank.GitVersioning.Tests.csproj"
+}


### PR DESCRIPTION
Adds a `.vscode` folder so you can debug unit tests from within VS Code.

(For this to work on Linux, you need to remove the project references to NerdBank.GitVersioning.LKG)