### PR TITLE
Re-route calls to GitExtensions.GitIdAsVersion, GetVersionHeight to VersionOracle

### DIFF
--- a/src/NerdBank.GitVersioning.Tests/BuildIntegrationTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/BuildIntegrationTests.cs
@@ -190,7 +190,7 @@ public class BuildIntegrationTests : RepoTestBase, IClassFixture<MSBuildFixture>
         this.WriteVersionFile("3.4");
         Assumes.True(repo.Index[VersionFile.JsonFileName] == null);
         var buildResult = await this.BuildAsync();
-        Assert.Equal("3.4.0." + repo.Head.Tip.GetIdAsVersion().Revision, buildResult.BuildVersion);
+        Assert.Equal("3.4.0." + GetIdAsVersion(repo, repo.Head.Tip).Revision, buildResult.BuildVersion);
         Assert.Equal("3.4.0+" + repo.Head.Tip.Id.Sha.Substring(0, VersionOptions.DefaultGitCommitIdShortFixedLength), buildResult.AssemblyInformationalVersion);
     }
 
@@ -215,7 +215,7 @@ public class BuildIntegrationTests : RepoTestBase, IClassFixture<MSBuildFixture>
         var repo = new Repository(this.RepoPath); // do not assign Repo property to avoid commits being generated later
         repo.Commit("empty", this.Signer, this.Signer, new CommitOptions { AllowEmptyCommit = true });
         var buildResult = await this.BuildAsync();
-        Assert.Equal("0.0.0." + repo.Head.Tip.GetIdAsVersion().Revision, buildResult.BuildVersion);
+        Assert.Equal("0.0.0." + GetIdAsVersion(repo, repo.Head.Tip).Revision, buildResult.BuildVersion);
         Assert.Equal("0.0.0+" + repo.Head.Tip.Id.Sha.Substring(0, VersionOptions.DefaultGitCommitIdShortFixedLength), buildResult.AssemblyInformationalVersion);
     }
 
@@ -295,7 +295,7 @@ public class BuildIntegrationTests : RepoTestBase, IClassFixture<MSBuildFixture>
         var buildResult = await this.BuildAsync();
         this.AssertStandardProperties(VersionOptions.FromVersion(new Version(majorMinorVersion)), buildResult);
 
-        Version version = this.Repo.Head.Tip.GetIdAsVersion();
+        Version version = this.GetIdAsVersion(this.Repo.Head.Tip);
         Assert.Equal($"{version.Major}.{version.Minor}.{buildResult.GitVersionHeight}", buildResult.NuGetPackageVersion);
     }
 
@@ -1002,9 +1002,9 @@ public class BuildIntegrationTests : RepoTestBase, IClassFixture<MSBuildFixture>
     private void AssertStandardProperties(VersionOptions versionOptions, BuildResults buildResult, string relativeProjectDirectory = null)
     {
         int versionHeight = this.GetVersionHeight(relativeProjectDirectory);
-        Version idAsVersion = this.Repo.GetIdAsVersion(relativeProjectDirectory);
+        Version idAsVersion = this.GetIdAsVersion(relativeProjectDirectory);
         string commitIdShort = this.CommitIdShort;
-        Version version = this.Repo.GetIdAsVersion(relativeProjectDirectory);
+        Version version = this.GetIdAsVersion(relativeProjectDirectory);
         Version assemblyVersion = GetExpectedAssemblyVersion(versionOptions, version);
         var additionalBuildMetadata = from item in buildResult.BuildResult.ProjectStateAfterBuild.GetItems("BuildMetadata")
                                       select item.EvaluatedInclude;

--- a/src/NerdBank.GitVersioning.Tests/BuildIntegrationTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/BuildIntegrationTests.cs
@@ -1001,7 +1001,7 @@ public class BuildIntegrationTests : RepoTestBase, IClassFixture<MSBuildFixture>
 
     private void AssertStandardProperties(VersionOptions versionOptions, BuildResults buildResult, string relativeProjectDirectory = null)
     {
-        int versionHeight = this.Repo.GetVersionHeight(relativeProjectDirectory);
+        int versionHeight = this.GetVersionHeight(relativeProjectDirectory);
         Version idAsVersion = this.Repo.GetIdAsVersion(relativeProjectDirectory);
         string commitIdShort = this.CommitIdShort;
         Version version = this.Repo.GetIdAsVersion(relativeProjectDirectory);

--- a/src/NerdBank.GitVersioning.Tests/RepoTestBase.Helpers.cs
+++ b/src/NerdBank.GitVersioning.Tests/RepoTestBase.Helpers.cs
@@ -51,4 +51,44 @@ public partial class RepoTestBase
         VersionOracle oracle = new VersionOracle(repoRelativeProjectDirectory == null ? repository.Info.WorkingDirectory : Path.Combine(repository.Info.WorkingDirectory, repoRelativeProjectDirectory), repository, null);
         return oracle.VersionHeight;
     }
+
+    /// <summary>
+    /// Encodes HEAD (or a modified working copy) from history in a <see cref="Version"/>
+    /// so that the original commit can be found later.
+    /// </summary>
+    /// <param name="repoRelativeProjectDirectory">The repo-relative project directory for which to calculate the version.</param>
+    /// <returns>
+    /// A version whose <see cref="Version.Build"/> and
+    /// <see cref="Version.Revision"/> components are calculated based on the commit.
+    /// </returns>
+    /// <remarks>
+    /// In the returned version, the <see cref="Version.Build"/> component is
+    /// the height of the git commit while the <see cref="Version.Revision"/>
+    /// component is the first four bytes of the git commit id (forced to be a positive integer).
+    /// </remarks>
+    protected System.Version GetIdAsVersion(string repoRelativeProjectDirectory = null)
+    {
+        VersionOracle oracle = new VersionOracle(
+            repoRelativeProjectDirectory == null ? this.Repo.Info.WorkingDirectory : Path.Combine(this.Repo.Info.WorkingDirectory, repoRelativeProjectDirectory),
+            this.Repo,
+            null);
+
+        return oracle.Version;
+    }
+
+    protected System.Version GetIdAsVersion(Commit commit, string repoRelativeProjectDirectory = null)
+    {
+        return GetIdAsVersion(this.Repo, commit, repoRelativeProjectDirectory);
+    }
+
+    protected static System.Version GetIdAsVersion(Repository repository, Commit commit, string repoRelativeProjectDirectory = null)
+    {
+        VersionOracle oracle = new VersionOracle(
+            repoRelativeProjectDirectory == null ? repository.Info.WorkingDirectory : Path.Combine(repository.Info.WorkingDirectory, repoRelativeProjectDirectory),
+            repository,
+            commit,
+            null);
+
+        return oracle.Version;
+    }
 }

--- a/src/NerdBank.GitVersioning.Tests/RepoTestBase.Helpers.cs
+++ b/src/NerdBank.GitVersioning.Tests/RepoTestBase.Helpers.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.IO;
+using LibGit2Sharp;
+using Nerdbank.GitVersioning;
+
+public partial class RepoTestBase
+{
+    /// <summary>
+    /// Gets the number of commits in the longest single path between
+    /// the specified commit and the most distant ancestor (inclusive)
+    /// that set the version to the value at the tip of the <paramref name="branch"/>.
+    /// </summary>
+    /// <param name="branch">The branch to measure the height of.</param>
+    /// <param name="repoRelativeProjectDirectory">The repo-relative project directory for which to calculate the version.</param>
+    /// <returns>The height of the branch till the version is changed.</returns>
+    protected int GetVersionHeight(Branch branch, string repoRelativeProjectDirectory = null)
+    {
+        var commit = branch.Tip ?? throw new InvalidOperationException("No commit exists.");
+        return this.GetVersionHeight(commit, repoRelativeProjectDirectory);
+    }
+    /// <summary>
+    /// Gets the number of commits in the longest single path between
+    /// the specified commit and the most distant ancestor (inclusive)
+    /// that set the version to the value at <paramref name="commit"/>.
+    /// </summary>
+    /// <param name="commit">The commit to measure the height of.</param>
+    /// <param name="repoRelativeProjectDirectory">The repo-relative project directory for which to calculate the version.</param>
+    /// <param name="baseVersion">Optional base version to calculate the height. If not specified, the base version will be calculated by scanning the repository.</param>
+    /// <returns>The height of the commit. Always a positive integer.</returns>
+    protected int GetVersionHeight(Commit commit, string repoRelativeProjectDirectory = null)
+    {
+        VersionOracle oracle = new VersionOracle(repoRelativeProjectDirectory == null ? this.RepoPath : Path.Combine(this.RepoPath, repoRelativeProjectDirectory), this.Repo, commit, null);
+        return oracle.VersionHeight;
+    }
+
+    /// <summary>
+    /// Gets the number of commits in the longest single path between
+    /// HEAD in a repo and the most distant ancestor (inclusive)
+    /// that set the version to the value in the working copy
+    /// (or HEAD for bare repositories).
+    /// </summary>
+    /// <param name="repoRelativeProjectDirectory">The repo-relative project directory for which to calculate the version.</param>
+    /// <returns>The height of the repo at HEAD. Always a positive integer.</returns>
+    protected int GetVersionHeight(string repoRelativeProjectDirectory = null)
+    {
+        return GetVersionHeight(this.Repo, repoRelativeProjectDirectory);
+    }
+
+    protected static int GetVersionHeight(Repository repository, string repoRelativeProjectDirectory = null)
+    {
+        VersionOracle oracle = new VersionOracle(repoRelativeProjectDirectory == null ? repository.Info.WorkingDirectory : Path.Combine(repository.Info.WorkingDirectory, repoRelativeProjectDirectory), repository, null);
+        return oracle.VersionHeight;
+    }
+}

--- a/src/NerdBank.GitVersioning.Tests/RepoTestBase.cs
+++ b/src/NerdBank.GitVersioning.Tests/RepoTestBase.cs
@@ -6,7 +6,7 @@ using Nerdbank.GitVersioning;
 using Validation;
 using Xunit.Abstractions;
 
-public abstract class RepoTestBase : IDisposable
+public abstract partial class RepoTestBase : IDisposable
 {
     private readonly List<string> repoDirectories = new List<string>();
 

--- a/src/NerdBank.GitVersioning.Tests/VersionFileTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/VersionFileTests.cs
@@ -485,10 +485,9 @@ public class VersionFileTests : RepoTestBase
     }
 
     [Theory]
-    [InlineData(false, false)]
-    [InlineData(true, false)]
-    [InlineData(true, true)]
-    public void VersionJson_Inheritance(bool commitInSourceControl, bool bareRepo)
+    [InlineData(false)]
+    [InlineData(true)]
+    public void VersionJson_Inheritance(bool commitInSourceControl)
     {
         if (commitInSourceControl)
         {
@@ -531,11 +530,6 @@ public class VersionFileTests : RepoTestBase
             "inheritWithVersion");
 
         Repository operatingRepo = this.Repo;
-        if (bareRepo)
-        {
-            operatingRepo = new Repository(
-                Repository.Clone(this.RepoPath, this.CreateDirectoryForNewRepo(), new CloneOptions { IsBare = true }));
-        }
 
         using (operatingRepo)
         {

--- a/src/NerdBank.GitVersioning.Tests/VersionFileTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/VersionFileTests.cs
@@ -573,13 +573,13 @@ public class VersionFileTests : RepoTestBase
 
                 // The version height should be the same for all those that inherit the version from the base,
                 // even though the inheriting files were introduced in successive commits.
-                Assert.Equal(totalCommits, operatingRepo.GetVersionHeight());
-                Assert.Equal(totalCommits, operatingRepo.GetVersionHeight("foo"));
-                Assert.Equal(totalCommits, operatingRepo.GetVersionHeight("foo/bar"));
+                Assert.Equal(totalCommits, GetVersionHeight(operatingRepo));
+                Assert.Equal(totalCommits, GetVersionHeight(operatingRepo, "foo"));
+                Assert.Equal(totalCommits, GetVersionHeight(operatingRepo, "foo/bar"));
 
                 // These either don't inherit, or inherit but reset versions, so the commits were reset.
-                Assert.Equal(2, operatingRepo.GetVersionHeight("noInherit"));
-                Assert.Equal(1, operatingRepo.GetVersionHeight("inheritWithVersion"));
+                Assert.Equal(2, GetVersionHeight(operatingRepo, "noInherit"));
+                Assert.Equal(1, GetVersionHeight(operatingRepo, "inheritWithVersion"));
             }
         }
     }

--- a/src/NerdBank.GitVersioning.Tests/VersionOracleTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/VersionOracleTests.cs
@@ -101,14 +101,14 @@ public class VersionOracleTests : RepoTestBase
 
         var oracle = VersionOracle.Create(this.RepoPath);
         Assert.Equal(11, oracle.VersionHeight);
-        Assert.Equal(11, this.Repo.Head.GetVersionHeight());
+        Assert.Equal(11, this.GetVersionHeight(this.Repo.Head));
 
         options.Version = SemanticVersion.Parse(next);
 
         this.WriteVersionFile(options);
         oracle = VersionOracle.Create(this.RepoPath);
         Assert.Equal(1, oracle.VersionHeight);
-        Assert.Equal(1, this.Repo.Head.GetVersionHeight());
+        Assert.Equal(1, this.GetVersionHeight(this.Repo.Head));
 
         foreach (var commit in this.Repo.Head.Commits)
         {

--- a/src/NerdBank.GitVersioning.Tests/VersionOracleTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/VersionOracleTests.cs
@@ -112,7 +112,7 @@ public class VersionOracleTests : RepoTestBase
 
         foreach (var commit in this.Repo.Head.Commits)
         {
-            var versionFromId = commit.GetIdAsVersion();
+            var versionFromId = this.GetIdAsVersion(commit);
             Assert.Contains(commit, this.Repo.GetCommitsFromVersion(versionFromId));
         }
     }

--- a/src/NerdBank.GitVersioning/GitExtensions.cs
+++ b/src/NerdBank.GitVersioning/GitExtensions.cs
@@ -212,7 +212,7 @@
         /// the height of the git commit while the <see cref="Version.Revision"/>
         /// component is the first four bytes of the git commit id (forced to be a positive integer).
         /// </remarks>
-        public static Version GetIdAsVersion(this Commit commit, string repoRelativeProjectDirectory = null, int? versionHeight = null)
+        internal static Version GetIdAsVersion(this Commit commit, string repoRelativeProjectDirectory = null, int? versionHeight = null)
         {
             Requires.NotNull(commit, nameof(commit));
             Requires.Argument(repoRelativeProjectDirectory == null || !Path.IsPathRooted(repoRelativeProjectDirectory), nameof(repoRelativeProjectDirectory), "Path should be relative to repo root.");
@@ -225,47 +225,6 @@
             }
 
             return GetIdAsVersionHelper(commit, versionOptions, versionHeight.Value);
-        }
-
-        /// <summary>
-        /// Encodes HEAD (or a modified working copy) from history in a <see cref="Version"/>
-        /// so that the original commit can be found later.
-        /// </summary>
-        /// <param name="repo">The repo whose ID and position in history is to be encoded.</param>
-        /// <param name="repoRelativeProjectDirectory">The repo-relative project directory for which to calculate the version.</param>
-        /// <param name="versionHeight">
-        /// The version height, previously calculated by a call to <see cref="GetVersionHeight(Commit, string, Version)"/>
-        /// with the same value for <paramref name="repoRelativeProjectDirectory"/>.
-        /// </param>
-        /// <returns>
-        /// A version whose <see cref="Version.Build"/> and
-        /// <see cref="Version.Revision"/> components are calculated based on the commit.
-        /// </returns>
-        /// <remarks>
-        /// In the returned version, the <see cref="Version.Build"/> component is
-        /// the height of the git commit while the <see cref="Version.Revision"/>
-        /// component is the first four bytes of the git commit id (forced to be a positive integer).
-        /// </remarks>
-        public static Version GetIdAsVersion(this Repository repo, string repoRelativeProjectDirectory = null, int? versionHeight = null)
-        {
-            Requires.NotNull(repo, nameof(repo));
-
-            var headCommit = repo.Head.Tip;
-            VersionOptions workingCopyVersionOptions, committedVersionOptions;
-            if (IsVersionFileChangedInWorkingCopy(repo, repoRelativeProjectDirectory, out committedVersionOptions, out workingCopyVersionOptions))
-            {
-                // Apply ordinary logic, but to the working copy version info.
-                if (!versionHeight.HasValue)
-                {
-                    var baseVersion = workingCopyVersionOptions?.Version?.Version;
-                    versionHeight = GetVersionHeight(headCommit, repoRelativeProjectDirectory, baseVersion);
-                }
-
-                Version result = GetIdAsVersionHelper(headCommit, workingCopyVersionOptions, versionHeight.Value);
-                return result;
-            }
-
-            return GetIdAsVersion(headCommit, repoRelativeProjectDirectory);
         }
 
         /// <summary>

--- a/src/NerdBank.GitVersioning/GitExtensions.cs
+++ b/src/NerdBank.GitVersioning/GitExtensions.cs
@@ -49,7 +49,7 @@
         /// <param name="repoRelativeProjectDirectory">The repo-relative project directory for which to calculate the version.</param>
         /// <param name="baseVersion">Optional base version to calculate the height. If not specified, the base version will be calculated by scanning the repository.</param>
         /// <returns>The height of the commit. Always a positive integer.</returns>
-        public static int GetVersionHeight(this Commit commit, string repoRelativeProjectDirectory = null, Version baseVersion = null)
+        internal static int GetVersionHeight(this Commit commit, string repoRelativeProjectDirectory = null, Version baseVersion = null)
         {
             Requires.NotNull(commit, nameof(commit));
             Requires.Argument(repoRelativeProjectDirectory == null || !Path.IsPathRooted(repoRelativeProjectDirectory), nameof(repoRelativeProjectDirectory), "Path should be relative to repo root.");
@@ -74,52 +74,6 @@
             }
 
             return 0;
-        }
-
-        /// <summary>
-        /// Gets the number of commits in the longest single path between
-        /// HEAD in a repo and the most distant ancestor (inclusive)
-        /// that set the version to the value in the working copy
-        /// (or HEAD for bare repositories).
-        /// </summary>
-        /// <param name="repo">The repo with the working copy / HEAD to measure the height of.</param>
-        /// <param name="repoRelativeProjectDirectory">The repo-relative project directory for which to calculate the version.</param>
-        /// <returns>The height of the repo at HEAD. Always a positive integer.</returns>
-        public static int GetVersionHeight(this Repository repo, string repoRelativeProjectDirectory = null)
-        {
-            if (repo == null)
-            {
-                return 0;
-            }
-
-            VersionOptions workingCopyVersionOptions, committedVersionOptions;
-            if (IsVersionFileChangedInWorkingCopy(repo, repoRelativeProjectDirectory, out committedVersionOptions, out workingCopyVersionOptions))
-            {
-                Version workingCopyVersion = workingCopyVersionOptions?.Version?.Version;
-                Version headCommitVersion = committedVersionOptions?.Version?.Version ?? Version0;
-                if (workingCopyVersion == null || !workingCopyVersion.Equals(headCommitVersion))
-                {
-                    // The working copy has changed the major.minor version.
-                    // So by definition the version height is 0, since no commit represents it yet.
-                    return 0;
-                }
-            }
-
-            // No special changes in the working directory, so apply regular logic.
-            return GetVersionHeight(repo.Head, repoRelativeProjectDirectory);
-        }
-
-        /// <summary>
-        /// Gets the number of commits in the longest single path between
-        /// the specified commit and the most distant ancestor (inclusive)
-        /// that set the version to the value at the tip of the <paramref name="branch"/>.
-        /// </summary>
-        /// <param name="branch">The branch to measure the height of.</param>
-        /// <param name="repoRelativeProjectDirectory">The repo-relative project directory for which to calculate the version.</param>
-        /// <returns>The height of the branch till the version is changed.</returns>
-        public static int GetVersionHeight(this Branch branch, string repoRelativeProjectDirectory = null)
-        {
-            return GetVersionHeight(branch.Tip ?? throw new InvalidOperationException("No commit exists."), repoRelativeProjectDirectory);
         }
 
         /// <summary>


### PR DESCRIPTION
- Update unit tests in `GitExtensionsTests` which excercise `GitIdAsVersion` to test `VersionOracle.Version` instead
- Update unit tests in `GitExtensionsTests` which excercise `GetVersionHeight` to test `VersionOracle.VersionHeight` instead

As per discussion in #524, a follow-up PR can move these tests to the `VersionOracleTests` class.

Contributes toward #505, #521 by making it easier to unit-test a managed implementation of the `VersionOracle` class.