### PR TITLE
Exclude vcxproj from `nbgv install` impact

### DIFF
--- a/src/nbgv/Program.cs
+++ b/src/nbgv/Program.cs
@@ -281,7 +281,7 @@ namespace Nerdbank.GitVersioning.Tool
                         { "Version", packageVersion },
                         { "PrivateAssets", "all" },
                     });
-                item.Condition = " '$(PlatformToolset)' == '' ";
+                item.Condition = "!Exists('packages.config')";
 
                 propsFile.Save(directoryBuildPropsPath);
             }


### PR DESCRIPTION
vcxproj doesn't support PackageReference, but when such an item exists it will try (and fail) after a package restore notices it.
We therefore need to suppress the item from such projects.

vcxproj _is_ supported by Nerdbank.GitVersioning, but it must be done by manual install of the package via packages.config for that project.

Fixes #533