### PR TITLE
Managed Git: .Dispose() housekeeping

### DIFF
--- a/src/NerdBank.GitVersioning/GitContext.cs
+++ b/src/NerdBank.GitVersioning/GitContext.cs
@@ -246,7 +246,10 @@ namespace Nerdbank.GitVersioning
             }
         }
 
-        /// <inheritdoc />
+        /// <summary>
+        /// Disposes of native and managed resources associated by this object.
+        /// </summary>
+        /// <param name="disposing"><see langword="true" /> to dispose managed and native resources; <see langword="false" /> to only dispose of native resources.</param>
         protected virtual void Dispose(bool disposing)
         {
         }

--- a/src/NerdBank.GitVersioning/Managed/ManagedGitContext.cs
+++ b/src/NerdBank.GitVersioning/Managed/ManagedGitContext.cs
@@ -122,7 +122,12 @@ namespace Nerdbank.GitVersioning.Managed
         /// <inheritdoc/>
         protected override void Dispose(bool disposing)
         {
-            this.Repository.Dispose();
+            if (disposing)
+            {
+                this.Repository.Dispose();
+            }
+
+            base.Dispose(disposing);
         }
 
         /// <summary>

--- a/src/NerdBank.GitVersioning/Managed/ManagedGitContext.cs
+++ b/src/NerdBank.GitVersioning/Managed/ManagedGitContext.cs
@@ -119,6 +119,12 @@ namespace Nerdbank.GitVersioning.Managed
             return this.Repository.ShortenObjectId(this.Commit.Value.Sha, minLength);
         }
 
+        /// <inheritdoc/>
+        protected override void Dispose(bool disposing)
+        {
+            this.Repository.Dispose();
+        }
+
         /// <summary>
         /// Encodes a commit from history in a <see cref="Version"/>
         /// so that the original commit can be found later.

--- a/src/NerdBank.GitVersioning/ManagedGit/GitPack.cs
+++ b/src/NerdBank.GitVersioning/ManagedGit/GitPack.cs
@@ -259,6 +259,7 @@ namespace Nerdbank.GitVersioning.ManagedGit
 
             this.accessor.Dispose();
             this.packFile.Dispose();
+            this.cache.Dispose();
         }
 
         private long? GetOffset(GitObjectId objectId)

--- a/src/NerdBank.GitVersioning/ManagedGit/GitPackCache.cs
+++ b/src/NerdBank.GitVersioning/ManagedGit/GitPackCache.cs
@@ -54,7 +54,17 @@ namespace Nerdbank.GitVersioning.ManagedGit
         public abstract Stream Add(long offset, Stream stream);
 
         /// <inheritdoc/>
-        public virtual void Dispose()
+        public void Dispose()
+        {
+            this.Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Disposes of native and managed resources associated by this object.
+        /// </summary>
+        /// <param name="disposing"><see langword="true" /> to dispose managed and native resources; <see langword="false" /> to only dispose of native resources.</param>
+        protected virtual void Dispose(bool disposing)
         {
         }
     }

--- a/src/NerdBank.GitVersioning/ManagedGit/GitPackCache.cs
+++ b/src/NerdBank.GitVersioning/ManagedGit/GitPackCache.cs
@@ -1,5 +1,6 @@
 ﻿#nullable enable
 
+using System;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Text;
@@ -12,7 +13,7 @@ namespace Nerdbank.GitVersioning.ManagedGit
     /// data from a <see cref="GitPack"/> can be potentially expensive: the data is
     /// compressed and can be deltified.
     /// </summary>
-    public abstract class GitPackCache
+    public abstract class GitPackCache : IDisposable
     {
         /// <summary>
         /// Attempts to retrieve a Git object from cache.
@@ -51,5 +52,10 @@ namespace Nerdbank.GitVersioning.ManagedGit
         /// A <see cref="Stream"/> which represents the cached entry.
         /// </returns>
         public abstract Stream Add(long offset, Stream stream);
+
+        /// <inheritdoc/>
+        public virtual void Dispose()
+        {
+        }
     }
 }

--- a/src/NerdBank.GitVersioning/ManagedGit/GitPackMemoryCache.cs
+++ b/src/NerdBank.GitVersioning/ManagedGit/GitPackMemoryCache.cs
@@ -3,6 +3,7 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
+using System.Linq;
 using System.Text;
 
 namespace Nerdbank.GitVersioning.ManagedGit
@@ -54,6 +55,18 @@ namespace Nerdbank.GitVersioning.ManagedGit
         public override void GetCacheStatistics(StringBuilder builder)
         {
             builder.AppendLine($"{this.cache.Count} items in cache");
+        }
+
+        /// <inheritdoc/>
+        public override void Dispose()
+        {
+            while (this.cache.Count > 0)
+            {
+                var key = this.cache.Keys.First();
+                var stream = this.cache[key];
+                stream.Dispose();
+                this.cache.Remove(key);
+            }
         }
     }
 }

--- a/src/NerdBank.GitVersioning/ManagedGit/GitPackMemoryCache.cs
+++ b/src/NerdBank.GitVersioning/ManagedGit/GitPackMemoryCache.cs
@@ -58,15 +58,20 @@ namespace Nerdbank.GitVersioning.ManagedGit
         }
 
         /// <inheritdoc/>
-        public override void Dispose()
+        protected override void Dispose(bool disposing)
         {
-            while (this.cache.Count > 0)
+            if (disposing)
             {
-                var key = this.cache.Keys.First();
-                var stream = this.cache[key];
-                stream.Dispose();
-                this.cache.Remove(key);
+                while (this.cache.Count > 0)
+                {
+                    var key = this.cache.Keys.First();
+                    var stream = this.cache[key];
+                    stream.Dispose();
+                    this.cache.Remove(key);
+                }
             }
+
+            base.Dispose(disposing);
         }
     }
 }

--- a/src/NerdBank.GitVersioning/ManagedGit/GitPackMemoryCacheStream.cs
+++ b/src/NerdBank.GitVersioning/ManagedGit/GitPackMemoryCacheStream.cs
@@ -101,8 +101,13 @@ namespace Nerdbank.GitVersioning.ManagedGit
 
         protected override void Dispose(bool disposing)
         {
-            this.stream.Dispose();
-            this.cacheStream.Dispose();
+            if (disposing)
+            {
+                this.stream.Dispose();
+                this.cacheStream.Dispose();
+            }
+
+            base.Dispose(disposing);
         }
 
         private void DisposeStreamIfRead()

--- a/src/NerdBank.GitVersioning/ManagedGit/GitPackMemoryCacheStream.cs
+++ b/src/NerdBank.GitVersioning/ManagedGit/GitPackMemoryCacheStream.cs
@@ -99,6 +99,12 @@ namespace Nerdbank.GitVersioning.ManagedGit
             throw new NotSupportedException();
         }
 
+        protected override void Dispose(bool disposing)
+        {
+            this.stream.Dispose();
+            this.cacheStream.Dispose();
+        }
+
         private void DisposeStreamIfRead()
         {
             if (this.cacheStream.Length == this.stream.Length)

--- a/src/NerdBank.GitVersioning/ManagedGit/MemoryMappedStream.cs
+++ b/src/NerdBank.GitVersioning/ManagedGit/MemoryMappedStream.cs
@@ -13,6 +13,7 @@ namespace Nerdbank.GitVersioning.ManagedGit
         private readonly long length;
         private long position;
         private byte* ptr;
+        private bool disposed;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MemoryMappedStream"/> class.
@@ -57,6 +58,11 @@ namespace Nerdbank.GitVersioning.ManagedGit
         /// <inheritdoc/>
         public override int Read(byte[] buffer, int offset, int count)
         {
+            if (this.disposed)
+            {
+                throw new ObjectDisposedException(nameof(MemoryMappedStream));
+            }
+
             int read = (int)Math.Min(count, this.length - this.position);
 
             new Span<byte>(this.ptr + this.position, read)
@@ -70,6 +76,11 @@ namespace Nerdbank.GitVersioning.ManagedGit
         /// <inheritdoc/>
         public override int Read(Span<byte> buffer)
         {
+            if (this.disposed)
+            {
+                throw new ObjectDisposedException(nameof(MemoryMappedStream));
+            }
+
             int read = (int)Math.Min(buffer.Length, this.length - this.position);
             
             new Span<byte>(this.ptr + this.position, read)
@@ -83,6 +94,11 @@ namespace Nerdbank.GitVersioning.ManagedGit
         /// <inheritdoc/>
         public override long Seek(long offset, SeekOrigin origin)
         {
+            if (this.disposed)
+            {
+                throw new ObjectDisposedException(nameof(MemoryMappedStream));
+            }
+
             long newPosition = this.position;
 
             switch (origin)
@@ -123,6 +139,13 @@ namespace Nerdbank.GitVersioning.ManagedGit
         public override void Write(byte[] buffer, int offset, int count)
         {
             throw new NotSupportedException();
+        }
+
+        /// <inheritdoc/>
+        protected override void Dispose(bool disposing)
+        {
+            this.accessor.SafeMemoryMappedViewHandle.ReleasePointer();
+            this.disposed = true;
         }
     }
 }

--- a/src/NerdBank.GitVersioning/ManagedGit/MemoryMappedStream.cs
+++ b/src/NerdBank.GitVersioning/ManagedGit/MemoryMappedStream.cs
@@ -144,8 +144,13 @@ namespace Nerdbank.GitVersioning.ManagedGit
         /// <inheritdoc/>
         protected override void Dispose(bool disposing)
         {
-            this.accessor.SafeMemoryMappedViewHandle.ReleasePointer();
-            this.disposed = true;
+            if (disposing)
+            {
+                this.accessor.SafeMemoryMappedViewHandle.ReleasePointer();
+                this.disposed = true;
+            }
+
+            base.Dispose(disposing);
         }
     }
 }


### PR DESCRIPTION
The root cause of #547 is that `MemoryMappedStream` calls `SafeMemoryMappedViewHandle.AcquirePointer(ref this.ptr)` without calling `SafeMemoryMappedViewHandle.ReleasePointer()`, never releasing the (virtual) memory.

On top of that, `ManagedGitContext.Dispose()` did not call `GitRepository.Dispose()`, and the `GitPackMemoryCache` was missing a `Dispose` method which frees up all the streams stored in the cache.

With this PR, a loop like this in `VersionOracleManagedTests`:

```
for (int i = 0; i < int.MaxValue; i++)
{
    var oracle = this.GetVersionOracle("path_to_repository");
    var version = oracle.Version;
}
```

goes from leaking 1 GB of memory / minute to a fairly stable state.