### PR TITLE
Added retries to SetCloudBuildVariable for GitHubActions

### DIFF
--- a/src/NerdBank.GitVersioning/CloudBuildServices/GitHubActions.cs
+++ b/src/NerdBank.GitVersioning/CloudBuildServices/GitHubActions.cs
@@ -28,7 +28,7 @@
 
         public IReadOnlyDictionary<string, string> SetCloudBuildVariable(string name, string value, TextWriter stdout, TextWriter stderr)
         {
-            File.AppendAllText(EnvironmentFile, $"{Environment.NewLine}{name}={value}{Environment.NewLine}");
+            Utilities.FileOperationWithRetry(() => File.AppendAllText(EnvironmentFile, $"{Environment.NewLine}{name}={value}{Environment.NewLine}"));
             return GetDictionaryFor(name, value);
         }
 


### PR DESCRIPTION
Updated the `GitHubActions` class to adopt retries in the `SetCloudBuildVariable` method.

This is an attempt to address occasional build failures I have seen in a GitHub Actions build.  The symptoms seem similar to #164.  I'm seeing errors similar to the following (slightly sanitized) in the logs.

```bash
C:\Users\runneradmin\.nuget\packages\nerdbank.gitversioning\3.3.37\build\Nerdbank.GitVersioning.targets(115,5): error MSB4018: The "Nerdbank.GitVersioning.Tasks.SetCloudBuildVariables" task failed unexpectedly. [D:\a\somepath\my.csproj]

C:\Users\runneradmin\.nuget\packages\nerdbank.gitversioning\3.3.37\build\Nerdbank.GitVersioning.targets(115,5): error MSB4018: System.IO.IOException: The process cannot access the file 'D:\a\_temp\_runner_file_commands\set_env_some_guid' because it is being used by another process. [D:\a\somepath\my.csproj]
```