### PR TITLE
Avoid writing garbage bytes to read blobs in managed git engine

### DIFF
--- a/src/NerdBank.GitVersioning/ManagedGit/GitPackMemoryCacheStream.cs
+++ b/src/NerdBank.GitVersioning/ManagedGit/GitPackMemoryCacheStream.cs
@@ -49,9 +49,9 @@ namespace Nerdbank.GitVersioning.ManagedGit
             {
                 var currentPosition = this.cacheStream.Position;
                 var toRead = (int)(buffer.Length - this.cacheStream.Length + this.cacheStream.Position);
-                this.stream.Read(buffer.Slice(0, toRead));
+                int actualRead = this.stream.Read(buffer.Slice(0, toRead));
                 this.cacheStream.Seek(0, SeekOrigin.End);
-                this.cacheStream.Write(buffer.Slice(0, toRead));
+                this.cacheStream.Write(buffer.Slice(0, actualRead));
                 this.cacheStream.Seek(currentPosition, SeekOrigin.Begin);
                 this.DisposeStreamIfRead();
             }


### PR DESCRIPTION
In the case of this bug, the `Stream.Read` method read fewer bytes than was requested. This is totally allowed, but the caller did not expect it and assumed the entire buffer was initialized rather than a subset of it.

Fixes #580
