### PR TITLE
Improve alternate parsing

### DIFF
--- a/src/NerdBank.GitVersioning.Tests/ManagedGit/GitRepositoryTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/ManagedGit/GitRepositoryTests.cs
@@ -286,6 +286,25 @@ namespace ManagedGit
             }
         }
 
+        [Fact]
+        public void ParseAlternates_SingleValue_Test()
+        {
+            var alternates = GitRepository.ParseAlternates(Encoding.UTF8.GetBytes("/home/git/nbgv/.git/objects\n"));
+            Assert.Collection(
+                alternates,
+                a => Assert.Equal("/home/git/nbgv/.git/objects", a));
+        }
+
+        [Fact]
+        public void ParseAlternates_TwoValues_Test()
+        {
+            var alternates = GitRepository.ParseAlternates(Encoding.UTF8.GetBytes("/home/git/nbgv/.git/objects:../../clone/.git/objects\n"));
+            Assert.Collection(
+                alternates,
+                a => Assert.Equal("/home/git/nbgv/.git/objects", a),
+                a => Assert.Equal("../../clone/.git/objects", a));
+        }
+
         private static void AssertPath(string expected, string actual)
         {
             Assert.Equal(

--- a/src/NerdBank.GitVersioning.Tests/ManagedGit/GitRepositoryTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/ManagedGit/GitRepositoryTests.cs
@@ -305,6 +305,19 @@ namespace ManagedGit
                 a => Assert.Equal("../../clone/.git/objects", a));
         }
 
+        [Fact]
+        public void ParseAlternates_PathWithColon_Test()
+        {
+            var alternates = GitRepository.ParseAlternates(
+                Encoding.UTF8.GetBytes("C:/Users/nbgv/objects:C:/Users/nbgv2/objects/:../../clone/.git/objects\n"),
+                2);
+            Assert.Collection(
+                alternates,
+                a => Assert.Equal("C:/Users/nbgv/objects", a),
+                a => Assert.Equal("C:/Users/nbgv2/objects/", a),
+                a => Assert.Equal("../../clone/.git/objects", a));
+        }
+
         private static void AssertPath(string expected, string actual)
         {
             Assert.Equal(

--- a/src/NerdBank.GitVersioning/ManagedGit/GitRepository.cs
+++ b/src/NerdBank.GitVersioning/ManagedGit/GitRepository.cs
@@ -111,7 +111,7 @@ namespace Nerdbank.GitVersioning.ManagedGit
                 var length = alternateStream!.Read(alternates);
                 alternates = alternates.Slice(0, length);
 
-                foreach(var alternate in ParseAlternates(alternates))
+                foreach (var alternate in ParseAlternates(alternates))
                 {
                     this.alternates.Add(
                         GitRepository.Create(
@@ -724,16 +724,29 @@ namespace Nerdbank.GitVersioning.ManagedGit
         /// A list of (relative) paths to the alternate object directories.
         /// </returns>
         public static List<string> ParseAlternates(ReadOnlySpan<byte> alternates)
+            => ParseAlternates(alternates, RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? 2 : 0);
+
+        /// <summary>
+        /// Parses the contents of the alternates file, and returns a list of (relative) paths to the alternate object directories.
+        /// </summary>
+        /// <param name="alternates">
+        /// The contents of the alternates files.
+        /// </param>
+        /// <param name="skipCount">
+        /// The number of bytes to skip in the span when looking for a delimiter.
+        /// </param>
+        /// <returns>
+        /// A list of (relative) paths to the alternate object directories.
+        /// </returns>
+        public static List<string> ParseAlternates(ReadOnlySpan<byte> alternates, int skipCount)
         {
             List<string> values = new List<string>();
 
-            int index = 0;
+            int index;
 
             // The alternates path is colon (:)-separated. On Windows, there may be full paths, such as
             // C:/Users/username/source/repos/nbgv/.git, which also contain a colon. Because the colon
             // can only appear at the second position, we skip the first two characters (e.g. C:) on Windows.
-            int skipCount = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? 2 : 0;
-
             while (alternates.Length > skipCount && (index = alternates.Slice(skipCount).IndexOfAny((byte)':', (byte)'\n')) > 0)
             {
                 values.Add(GetString(alternates.Slice(0, skipCount + index)));

--- a/src/NerdBank.GitVersioning/ManagedGit/GitRepository.cs
+++ b/src/NerdBank.GitVersioning/ManagedGit/GitRepository.cs
@@ -721,7 +721,8 @@ namespace Nerdbank.GitVersioning.ManagedGit
         /// The contents of the alternates files.
         /// </param>
         /// <returns>
-        /// A list of (relative) paths to the alternate object directories.</returns>
+        /// A list of (relative) paths to the alternate object directories.
+        /// </returns>
         public static List<string> ParseAlternates(ReadOnlySpan<byte> alternates)
         {
             List<string> values = new List<string>();


### PR DESCRIPTION
There are at least two bugs in alternate parsing:
- On all platforms, the last value in the alternate files is ignored
- On Windows, the colon in full paths (e.g. `C:\Users\Me`) is used as a separator

This PR attempts to fix both issues. Contributes towards #595