### PR TITLE
Abort prepare-release command when version on current branch is not incremented

### DIFF
--- a/src/NerdBank.GitVersioning.Tests/ReleaseManagerTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/ReleaseManagerTests.cs
@@ -392,10 +392,28 @@ public abstract class ReleaseManagerTests : RepoTestBase
         this.WriteVersionFile(versionOptions);
 
         // running PrepareRelease should result in an error
-        // because we're trying to add a prerelease tag to a version without prerelease tag
+        // because we're setting the version on master to a lower version
         this.AssertError(
             () => new ReleaseManager().PrepareRelease(this.RepoPath, releaseUnstableTag, (nextVersion == null ? null : Version.Parse(nextVersion))),
             ReleasePreparationError.VersionDecrement);
+    }
+
+    [Theory]
+    [InlineData("1.2", "1.2")]
+    public void PrepareRelease_MasterWithoutVersionIncrement(string initialVersion, string nextVersion)
+    {
+        // create and configure repository
+        this.InitializeSourceControl();
+
+        // create version.json
+        var versionOptions = new VersionOptions() { Version = SemanticVersion.Parse(initialVersion) };
+        this.WriteVersionFile(versionOptions);
+
+        // running PrepareRelease should result in an error
+        // because we're trying to set master to the version it already has
+        this.AssertError(
+            () => new ReleaseManager().PrepareRelease(this.RepoPath, null, (nextVersion == null ? null : Version.Parse(nextVersion))),
+            ReleasePreparationError.NoVersionIncrement);
     }
 
     [Fact]

--- a/src/NerdBank.GitVersioning/ReleaseManager.cs
+++ b/src/NerdBank.GitVersioning/ReleaseManager.cs
@@ -48,6 +48,11 @@
             VersionDecrement,
 
             /// <summary>
+            /// Branch cannot be set to the specified version because the new version is not higher than the current version
+            /// </summary>
+            NoVersionIncrement,
+
+            /// <summary>
             /// Cannot create a branch because it already exists
             /// </summary>
             BranchAlreadyExists,
@@ -272,6 +277,14 @@
             }
 
             var nextDevVersion = this.GetNextDevVersion(versionOptions, nextVersion, versionIncrement);
+
+            // check if the current version on the main branch is different from the next version
+            // otherwise, both the release branch and the dev branch would have the same version
+            if (versionOptions.Version.Version == nextDevVersion.Version)
+            {
+                this.stderr.WriteLine($"Version on '{originalBranchName}' is already set to next version {nextDevVersion.Version}.");
+                throw new ReleasePreparationException(ReleasePreparationError.NoVersionIncrement);
+            }
 
             // check if the release branch already exists
             if (repository.Branches[releaseBranchName] != null)

--- a/src/NerdBank.GitVersioning/ReleaseManager.cs
+++ b/src/NerdBank.GitVersioning/ReleaseManager.cs
@@ -278,7 +278,7 @@
 
             var nextDevVersion = this.GetNextDevVersion(versionOptions, nextVersion, versionIncrement);
 
-            // check if the current version on the main branch is different from the next version
+            // check if the current version on the current branch is different from the next version
             // otherwise, both the release branch and the dev branch would have the same version
             if (versionOptions.Version.Version == nextDevVersion.Version)
             {

--- a/src/nbgv/Program.cs
+++ b/src/nbgv/Program.cs
@@ -736,6 +736,7 @@ namespace Nerdbank.GitVersioning.Tool
                     case ReleaseManager.ReleasePreparationError.NoVersionFile:
                         return (int)ExitCodes.NoVersionJsonFound;
                     case ReleaseManager.ReleasePreparationError.VersionDecrement:
+                    case ReleaseManager.ReleasePreparationError.NoVersionIncrement:
                         return (int)ExitCodes.InvalidVersionSpec;
                     case ReleaseManager.ReleasePreparationError.BranchAlreadyExists:
                         return (int)ExitCodes.BranchAlreadyExists;


### PR DESCRIPTION
When the next version for the current branch is set by the user using the `--nextVersion` command line parameter, the next version might be equal to the current version.
In that case no commit is created (no changes on the branch), which in turn causes the current branch to be fast-forwarded to the commit on the newly-created release branch when the branches are merged.

To prevent this error, abort command if both versions match (there is already a check in place that prevents the version from being decremented).

The check only applies to the current branch because the version on the release branch not being incremented is a valid use case.

This should fix #591