### PR TITLE
Don't require a trailing `\n` character at the end of the alternates file

### DIFF
--- a/src/NerdBank.GitVersioning.Tests/ManagedGit/GitRepositoryTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/ManagedGit/GitRepositoryTests.cs
@@ -296,6 +296,15 @@ namespace ManagedGit
         }
 
         [Fact]
+        public void ParseAlternates_SingleValue_NoTrailingNewline_Test()
+        {
+            var alternates = GitRepository.ParseAlternates(Encoding.UTF8.GetBytes("../repo/.git/objects"));
+            Assert.Collection(
+                alternates,
+                a => Assert.Equal("../repo/.git/objects", a));
+        }
+
+        [Fact]
         public void ParseAlternates_TwoValues_Test()
         {
             var alternates = GitRepository.ParseAlternates(Encoding.UTF8.GetBytes("/home/git/nbgv/.git/objects:../../clone/.git/objects\n"));

--- a/src/NerdBank.GitVersioning/ManagedGit/GitRepository.cs
+++ b/src/NerdBank.GitVersioning/ManagedGit/GitRepository.cs
@@ -751,14 +751,18 @@ namespace Nerdbank.GitVersioning.ManagedGit
             List<string> values = new List<string>();
 
             int index;
+            int length;
 
             // The alternates path is colon (:)-separated. On Windows, there may be full paths, such as
             // C:/Users/username/source/repos/nbgv/.git, which also contain a colon. Because the colon
             // can only appear at the second position, we skip the first two characters (e.g. C:) on Windows.
-            while (alternates.Length > skipCount && (index = alternates.Slice(skipCount).IndexOfAny((byte)':', (byte)'\n')) > 0)
+            while (alternates.Length > skipCount)
             {
-                values.Add(GetString(alternates.Slice(0, skipCount + index)));
-                alternates = alternates.Slice(skipCount + index + 1);
+                index = alternates.Slice(skipCount).IndexOfAny((byte)':', (byte)'\n');
+                length = index > 0 ? skipCount + index : alternates.Length;
+
+                values.Add(GetString(alternates.Slice(0, length)));
+                alternates = index > 0 ? alternates.Slice(length + 1) : Span<byte>.Empty;
             }
 
             return values;


### PR DESCRIPTION
The documentation for alternates is sparse, but the example in https://git.wiki.kernel.org/index.php/GitTips#How_to_compare_two_local_repositories does not contain a trailing `\n` character.

Potential fix for #595