### PR TITLE
Include missing zlib compression level header checks

### DIFF
--- a/src/NerdBank.GitVersioning/ManagedGit/ZLibStream.cs
+++ b/src/NerdBank.GitVersioning/ManagedGit/ZLibStream.cs
@@ -5,7 +5,6 @@ using System;
 using System.Buffers;
 using System.IO;
 using System.IO.Compression;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -59,7 +58,7 @@ namespace Nerdbank.GitVersioning.ManagedGit
 
             if (zlibHeader[0] != 0x78 || (zlibHeader[1] != 0x01 && zlibHeader[1] != 0x9C && zlibHeader[1] != 0x5E && zlibHeader[1] != 0xDA))
             {
-                throw new GitException($"Invalid zlib header {string.Join(" ", zlibHeader.ToArray().Select(b => $"{b:X2}"))}");
+                throw new GitException($"Invalid zlib header {zlibHeader[0]:X2} {zlibHeader[1]:X2}");
             }
         }
 

--- a/src/NerdBank.GitVersioning/ManagedGit/ZLibStream.cs
+++ b/src/NerdBank.GitVersioning/ManagedGit/ZLibStream.cs
@@ -5,6 +5,7 @@ using System;
 using System.Buffers;
 using System.IO;
 using System.IO.Compression;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -56,9 +57,9 @@ namespace Nerdbank.GitVersioning.ManagedGit
             Span<byte> zlibHeader = stackalloc byte[2];
             stream.ReadAll(zlibHeader);
 
-            if (zlibHeader[0] != 0x78 || (zlibHeader[1] != 0x01 && zlibHeader[1] != 0x9C))
+            if (zlibHeader[0] != 0x78 || (zlibHeader[1] != 0x01 && zlibHeader[1] != 0x9C && zlibHeader[1] != 0x5E && zlibHeader[1] != 0xDA))
             {
-                throw new GitException();
+                throw new GitException($"Invalid zlib header {string.Join(" ", zlibHeader.ToArray().Select(b => $"{b:X2}"))}");
             }
         }
 


### PR DESCRIPTION
Should fix nbgv failing for repos that have objects compressed with zlib levels 2-5 (header `0x78 0x5E`) and 7-9 (`0x78 0xDA`). If required, I can embed zz files of different compression levels and implements tests for those.

Fixes #619

