### PR TITLE
GitPack: Don't use memory mapped streams when accessing pack files

### DIFF
--- a/src/NerdBank.GitVersioning.Tests/ManagedGit/GitPackTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/ManagedGit/GitPackTests.cs
@@ -136,14 +136,24 @@ namespace ManagedGit
             using (SHA1 sha = SHA1.Create())
             {
                 Assert.True(gitPack.TryGetObject(GitObjectId.Parse("f5b401f40ad83f13030e946c9ea22cb54cb853cd"), "commit", out Stream commitStream));
+                using (commitStream)
+                {
+                    // This commit is not deltafied. It is stored as a .gz-compressed stream in the pack file.
+                    var zlibStream = Assert.IsType<ZLibStream>(commitStream);
+                    var deflateStream = Assert.IsType<DeflateStream>(zlibStream.BaseStream);
 
-                // This commit is not deltafied. It is stored as a .gz-compressed stream in the pack file.
-                var zlibStream = Assert.IsType<ZLibStream>(commitStream);
-                var deflateStream = Assert.IsType<DeflateStream>(zlibStream.BaseStream);
-                var pooledStream = Assert.IsType<MemoryMappedStream>(deflateStream.BaseStream);
+                    if (IntPtr.Size > 4)
+                    {
+                        var pooledStream = Assert.IsType<MemoryMappedStream>(deflateStream.BaseStream);
+                    }
+                    else
+                    {
+                        var directAccessStream = Assert.IsType<FileStream>(deflateStream.BaseStream);
+                    }
 
-                Assert.Equal(222, commitStream.Length);
-                Assert.Equal("/zgldANj+jvgOwlecnOKylZDVQg=", Convert.ToBase64String(sha.ComputeHash(commitStream)));
+                    Assert.Equal(222, commitStream.Length);
+                    Assert.Equal("/zgldANj+jvgOwlecnOKylZDVQg=", Convert.ToBase64String(sha.ComputeHash(commitStream)));
+                }
             }
         }
 

--- a/src/NerdBank.GitVersioning.Tests/ManagedGit/GitPackTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/ManagedGit/GitPackTests.cs
@@ -63,7 +63,15 @@ namespace ManagedGit
                 // This commit is not deltafied. It is stored as a .gz-compressed stream in the pack file.
                 var zlibStream = Assert.IsType<ZLibStream>(commitStream);
                 var deflateStream = Assert.IsType<DeflateStream>(zlibStream.BaseStream);
-                var pooledStream = Assert.IsType<MemoryMappedStream>(deflateStream.BaseStream);
+
+                if (IntPtr.Size > 4)
+                {
+                    var pooledStream = Assert.IsType<MemoryMappedStream>(deflateStream.BaseStream);
+                }
+                else
+                {
+                    var pooledStream = Assert.IsType<FileStream>(deflateStream.BaseStream);
+                }
 
                 Assert.Equal(222, commitStream.Length);
                 Assert.Equal("/zgldANj+jvgOwlecnOKylZDVQg=", Convert.ToBase64String(sha.ComputeHash(commitStream)));
@@ -85,7 +93,15 @@ namespace ManagedGit
                 var deltaStream = Assert.IsType<GitPackDeltafiedStream>(commitStream);
                 var zlibStream = Assert.IsType<ZLibStream>(deltaStream.BaseStream);
                 var deflateStream = Assert.IsType<DeflateStream>(zlibStream.BaseStream);
-                var pooledStream = Assert.IsType<MemoryMappedStream>(deflateStream.BaseStream);
+
+                if (IntPtr.Size > 4)
+                {
+                    var pooledStream = Assert.IsType<MemoryMappedStream>(deflateStream.BaseStream);
+                }
+                else
+                {
+                    var directAccessStream = Assert.IsType<FileStream>(deflateStream.BaseStream);
+                }
 
                 Assert.Equal(137, commitStream.Length);
                 Assert.Equal("lZu/7nGb0n1UuO9SlPluFnSvj4o=", Convert.ToBase64String(sha.ComputeHash(commitStream)));

--- a/src/NerdBank.GitVersioning/ManagedGit/GitPack.cs
+++ b/src/NerdBank.GitVersioning/ManagedGit/GitPack.cs
@@ -205,7 +205,17 @@ namespace Nerdbank.GitVersioning.ManagedGit
             }
 
             var packStream = this.GetPackStream();
-            Stream objectStream = GitPackReader.GetObject(this, packStream, offset, objectType, packObjectType);
+            Stream objectStream;
+
+            try
+            {
+                objectStream = GitPackReader.GetObject(this, packStream, offset, objectType, packObjectType);
+            }
+            catch
+            {
+                packStream.Dispose();
+                throw;
+            }
 
             return this.cache.Add(offset, objectStream);
         }


### PR DESCRIPTION
This commit preserves the usage of memory mapped streams when reading the pack _index_, but reverts to using standard streams when reading raw data in pack files on 32-bit operating systems.

Fixes #584