### PR TITLE
Fix bugs with > 2 GB pack files

### DIFF
--- a/src/NerdBank.GitVersioning/ManagedGit/GitPackIndexMappedReader.cs
+++ b/src/NerdBank.GitVersioning/ManagedGit/GitPackIndexMappedReader.cs
@@ -128,7 +128,7 @@ namespace Nerdbank.GitVersioning.ManagedGit
             {
                 // If the first bit of the offset address is set, the offset is stored as a 64-bit value in the table of 8-byte offset entries,
                 // which follows the table of 4-byte offset entries: "large offsets are encoded as an index into the next table with the msbit set."
-                offset = offset & 0x7FF;
+                offset = offset & 0x7FFFFFFF;
 
                 offsetBuffer = this.Value.Slice(offsetTableStart + 4 * objectCount + 8 * (int)offset, 8);
                 var offset64 = BinaryPrimitives.ReadInt64BigEndian(offsetBuffer);

--- a/src/NerdBank.GitVersioning/ManagedGit/GitPackReader.cs
+++ b/src/NerdBank.GitVersioning/ManagedGit/GitPackReader.cs
@@ -44,7 +44,7 @@ namespace Nerdbank.GitVersioning.ManagedGit
             if (type == GitPackObjectType.OBJ_OFS_DELTA)
             {
                 var baseObjectRelativeOffset = ReadVariableLengthInteger(stream);
-                var baseObjectOffset = (int)(offset - baseObjectRelativeOffset);
+                var baseObjectOffset = offset - baseObjectRelativeOffset;
 
                 var deltaStream = new ZLibStream(stream, decompressedSize);
                 var baseObjectStream = pack.GetObject(baseObjectOffset, objectType);
@@ -98,9 +98,9 @@ namespace Nerdbank.GitVersioning.ManagedGit
             return (type, length);
         }
 
-        private static int ReadVariableLengthInteger(Stream stream)
+        private static long ReadVariableLengthInteger(Stream stream)
         {
-            int offset = -1;
+            long offset = -1;
             int b;
 
             do

--- a/src/NerdBank.GitVersioning/ManagedGit/GitPackReader.cs
+++ b/src/NerdBank.GitVersioning/ManagedGit/GitPackReader.cs
@@ -44,7 +44,7 @@ namespace Nerdbank.GitVersioning.ManagedGit
             if (type == GitPackObjectType.OBJ_OFS_DELTA)
             {
                 var baseObjectRelativeOffset = ReadVariableLengthInteger(stream);
-                var baseObjectOffset = offset - baseObjectRelativeOffset;
+                long baseObjectOffset = offset - baseObjectRelativeOffset;
 
                 var deltaStream = new ZLibStream(stream, decompressedSize);
                 var baseObjectStream = pack.GetObject(baseObjectOffset, objectType);


### PR DESCRIPTION
Unfortunately it's non-trivial to make a test for this since it requires really large data. The obvious bug is the incorrect mask in the `.idx` file reading which resulted in incorrect offset being read. The other two bugs happen if a delta is crossing the 2GB boundary in the pack file.