### PR TITLE
Fixes build with msbuild `-graph -isolate` switches

### DIFF
--- a/src/Nerdbank.GitVersioning.Tasks/build/Nerdbank.GitVersioning.Inner.targets
+++ b/src/Nerdbank.GitVersioning.Tasks/build/Nerdbank.GitVersioning.Inner.targets
@@ -42,5 +42,11 @@
     <Message Importance="low" Text="AssemblyInformationalVersion: $(AssemblyInformationalVersion)" />
     <Message Importance="low" Text="NuGetPackageVersion: $(NuGetPackageVersion)" />
   </Target>
+  
+  <!-- These targets are called by MSBuild static graph because we declare a ProjectReference item to this file. -->
+  <Target Name="GetTargetFrameworks" />
+  <Target Name="GetNativeManifest" />
+  <Target Name="GetCopyToOutputDirectoryItems" />
+  <Target Name="GetTargetFrameworksWithPlatformForSingleTargetFramework" />
 
 </Project>

--- a/src/Nerdbank.GitVersioning.Tasks/build/Nerdbank.GitVersioning.targets
+++ b/src/Nerdbank.GitVersioning.Tasks/build/Nerdbank.GitVersioning.targets
@@ -76,6 +76,8 @@
   <!-- Compile a list of global properties that may vary when a project builds but that would never influence the result of the GetBuildVersion task. -->
   <ItemGroup>
     <NBGV_GlobalPropertiesToRemove Include="TargetFramework" />
+    <NBGV_GlobalPropertiesToRemove Include="Configuration" />
+    <NBGV_GlobalPropertiesToRemove Include="Platform" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Nerdbank.GitVersioning.Tasks/build/Nerdbank.GitVersioning.targets
+++ b/src/Nerdbank.GitVersioning.Tasks/build/Nerdbank.GitVersioning.targets
@@ -79,6 +79,8 @@
     <NBGV_GlobalPropertiesToRemove Include="RuntimeIdentifier" />
     <NBGV_GlobalPropertiesToRemove Include="Configuration" />
     <NBGV_GlobalPropertiesToRemove Include="Platform" />
+  
+    <_BuildMetadataSnapped Include="@(BuildMetadata)" />
   </ItemGroup>
 
   <ItemGroup>
@@ -97,6 +99,8 @@
   </ItemGroup>
 
   <Target Name="GetBuildVersion" Returns="$(BuildVersion)">
+    <Error Text="BuildMetadata items changed after a copy was made. Add all BuildMetadata items before importing this file." Condition=" '@(BuildMetadata)' != '@(_BuildMetadataSnapped)' " />
+    
     <!-- Calculate version by invoking another "project" with global properties that will serve as a key 
          into an msbuild cache to ensure we only invoke the GetBuildVersion task as many times as will produce a unique value. -->
     <MSBuild Projects="@(ProjectReference)"

--- a/src/Nerdbank.GitVersioning.Tasks/build/Nerdbank.GitVersioning.targets
+++ b/src/Nerdbank.GitVersioning.Tasks/build/Nerdbank.GitVersioning.targets
@@ -91,13 +91,18 @@
       <BuildReference>false</BuildReference>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
       <Visible>false</Visible>
+      <NBGV_InnerProject>true</NBGV_InnerProject>
     </ProjectReference>
   </ItemGroup>
 
   <Target Name="GetBuildVersion" Returns="$(BuildVersion)">
     <!-- Calculate version by invoking another "project" with global properties that will serve as a key 
          into an msbuild cache to ensure we only invoke the GetBuildVersion task as many times as will produce a unique value. -->
-    <MSBuild Projects="$(NBGV_CoreTargets)" Properties="$(NBGV_InnerGlobalProperties)" RemoveProperties="@(NBGV_GlobalPropertiesToRemove)" Targets="GetBuildVersion_Properties">
+    <MSBuild Projects="@(ProjectReference)"
+             Condition=" '%(ProjectReference.NBGV_InnerProject)' == 'true' "
+             Properties="%(ProjectReference.Properties)"
+             RemoveProperties="%(ProjectReference.GlobalPropertiesToRemove)"
+             Targets="GetBuildVersion_Properties">
       <Output TaskParameter="TargetOutputs" ItemName="NBGV_PropertyItems" />
     </MSBuild>
 
@@ -114,7 +119,11 @@
     </PropertyGroup>
 
     <!-- Also get other items. -->
-    <MSBuild Projects="$(NBGV_CoreTargets)" Properties="$(NBGV_InnerGlobalProperties)" RemoveProperties="@(NBGV_GlobalPropertiesToRemove)" Targets="GetBuildVersion_CloudBuildVersionVars">
+    <MSBuild Projects="@(ProjectReference)"
+             Condition=" '%(ProjectReference.NBGV_InnerProject)' == 'true' "
+             Properties="%(ProjectReference.Properties)"
+             RemoveProperties="%(ProjectReference.GlobalPropertiesToRemove)"
+             Targets="GetBuildVersion_CloudBuildVersionVars">
       <Output TaskParameter="TargetOutputs" ItemName="CloudBuildVersionVars" />
     </MSBuild>
   </Target>

--- a/src/Nerdbank.GitVersioning.Tasks/build/Nerdbank.GitVersioning.targets
+++ b/src/Nerdbank.GitVersioning.Tasks/build/Nerdbank.GitVersioning.targets
@@ -62,28 +62,37 @@
     <!-- Consider building a tag to be more precise than the branch we're building. -->
     <_NBGV_BuildingRef>$(_NBGV_BuildingTag)</_NBGV_BuildingRef>
     <_NBGV_BuildingRef Condition=" '$(_NBGV_BuildingRef)' == '' ">$(_NBGV_BuildingBranch)</_NBGV_BuildingRef>
+
+    <GitVersionBaseDirectory Condition=" '$(GitVersionBaseDirectory)' == '' ">$(MSBuildProjectDirectory)</GitVersionBaseDirectory>
+    <NBGV_InnerGlobalProperties Condition=" '$(GitRepoRoot)' != '' ">$(NBGV_InnerGlobalProperties)GitRepoRoot=$(GitRepoRoot);</NBGV_InnerGlobalProperties>
+    <NBGV_InnerGlobalProperties Condition=" '$(PublicRelease)' != '' ">$(NBGV_InnerGlobalProperties)PublicRelease=$(PublicRelease);</NBGV_InnerGlobalProperties>
+    <NBGV_InnerGlobalProperties Condition=" '$(_NBGV_BuildingRef)' != '' ">$(NBGV_InnerGlobalProperties)_NBGV_BuildingRef=$(_NBGV_BuildingRef);</NBGV_InnerGlobalProperties>
+    <NBGV_InnerGlobalProperties Condition=" '$(ProjectPathRelativeToGitRepoRoot)' != '' ">$(NBGV_InnerGlobalProperties)ProjectPathRelativeToGitRepoRoot=$(ProjectPathRelativeToGitRepoRoot);</NBGV_InnerGlobalProperties>
+    <NBGV_InnerGlobalProperties Condition=" '$(GitVersionBaseDirectory)' != '' ">$(NBGV_InnerGlobalProperties)ProjectDirectory=$(GitVersionBaseDirectory);</NBGV_InnerGlobalProperties>
+    <NBGV_InnerGlobalProperties Condition=" '$(OverrideBuildNumberOffset)' != '' ">$(NBGV_InnerGlobalProperties)OverrideBuildNumberOffset=$(OverrideBuildNumberOffset);</NBGV_InnerGlobalProperties>
+    <NBGV_CoreTargets>$(MSBuildThisFileDirectory)Nerdbank.GitVersioning.Inner.targets</NBGV_CoreTargets>
   </PropertyGroup>
 
+  <!-- Compile a list of global properties that may vary when a project builds but that would never influence the result of the GetBuildVersion task. -->
+  <ItemGroup>
+    <NBGV_GlobalPropertiesToRemove Include="TargetFramework" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Declare a P2P so that "msbuild -graph -isolate" doesn't complain when we use the MSBuild task to invoke our inner shared project. -->
+    <ProjectReference Include="$(NBGV_CoreTargets)">
+      <Targets>GetBuildVersion_Properties;GetBuildVersion_CloudBuildVersionVars</Targets>
+      <Properties>$(NBGV_InnerGlobalProperties)BuildMetadata=@(BuildMetadata, ',');</Properties>
+      <GlobalPropertiesToRemove>@(NBGV_GlobalPropertiesToRemove)</GlobalPropertiesToRemove>
+
+      <!-- Do our very best to prevent Microsoft.Common.CurrentVersion.targets or IDEs from processing this P2P. It's only here for MSBuild's static graph. -->
+      <BuildReference>false</BuildReference>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <Visible>false</Visible>
+    </ProjectReference>
+  </ItemGroup>
+
   <Target Name="GetBuildVersion" Returns="$(BuildVersion)">
-    <PropertyGroup>
-      <GitVersionBaseDirectory Condition=" '$(GitVersionBaseDirectory)' == '' ">$(MSBuildProjectDirectory)</GitVersionBaseDirectory>
-      <NBGV_InnerGlobalProperties>
-        GitRepoRoot=$(GitRepoRoot);
-        PublicRelease=$(PublicRelease);
-        BuildMetadata=@(BuildMetadata, ',');
-        _NBGV_BuildingRef=$(_NBGV_BuildingRef);
-        ProjectPathRelativeToGitRepoRoot=$(ProjectPathRelativeToGitRepoRoot);
-        ProjectDirectory=$(GitVersionBaseDirectory);
-        OverrideBuildNumberOffset=$(OverrideBuildNumberOffset);
-      </NBGV_InnerGlobalProperties>
-      <NBGV_CoreTargets>$(MSBuildThisFileDirectory)Nerdbank.GitVersioning.Inner.targets</NBGV_CoreTargets>
-    </PropertyGroup>
-
-    <!-- Compile a list of global properties that may vary when a project builds but that would never influence the result of the GetBuildVersion task. -->
-    <ItemGroup>
-      <NBGV_GlobalPropertiesToRemove Include="TargetFramework" />
-    </ItemGroup>
-
     <!-- Calculate version by invoking another "project" with global properties that will serve as a key 
          into an msbuild cache to ensure we only invoke the GetBuildVersion task as many times as will produce a unique value. -->
     <MSBuild Projects="$(NBGV_CoreTargets)" Properties="$(NBGV_InnerGlobalProperties)" RemoveProperties="@(NBGV_GlobalPropertiesToRemove)" Targets="GetBuildVersion_Properties">

--- a/src/Nerdbank.GitVersioning.Tasks/build/Nerdbank.GitVersioning.targets
+++ b/src/Nerdbank.GitVersioning.Tasks/build/Nerdbank.GitVersioning.targets
@@ -93,6 +93,7 @@
       <!-- Do our very best to prevent Microsoft.Common.CurrentVersion.targets or IDEs from processing this P2P. It's only here for MSBuild's static graph. -->
       <BuildReference>false</BuildReference>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <SkipGetTargetFrameworkProperties>true</SkipGetTargetFrameworkProperties>
       <Visible>false</Visible>
       <NBGV_InnerProject>true</NBGV_InnerProject>
     </ProjectReference>

--- a/src/Nerdbank.GitVersioning.Tasks/build/Nerdbank.GitVersioning.targets
+++ b/src/Nerdbank.GitVersioning.Tasks/build/Nerdbank.GitVersioning.targets
@@ -76,6 +76,7 @@
   <!-- Compile a list of global properties that may vary when a project builds but that would never influence the result of the GetBuildVersion task. -->
   <ItemGroup>
     <NBGV_GlobalPropertiesToRemove Include="TargetFramework" />
+    <NBGV_GlobalPropertiesToRemove Include="RuntimeIdentifier" />
     <NBGV_GlobalPropertiesToRemove Include="Configuration" />
     <NBGV_GlobalPropertiesToRemove Include="Platform" />
   </ItemGroup>


### PR DESCRIPTION
Fixes #647 

- [x] Document breaking changes around when `BuildMetadata` items have to be declared.
- [x] File bugs against msbuild for how the global property syntax of P2Ps is interpreted differently by static graph than the msbuild task itself.