### PR TITLE
inheritance fixes and better path filtering

### DIFF
--- a/src/NerdBank.GitVersioning/FilterPath.cs
+++ b/src/NerdBank.GitVersioning/FilterPath.cs
@@ -10,7 +10,7 @@ namespace Nerdbank.GitVersioning
     /// <summary>
     /// A filter (include or exclude) representing a repo relative path.
     /// </summary>
-    public class FilterPath
+    public class FilterPath : IEquatable<FilterPath>
     {
         /// <summary>
         /// True if this <see cref="FilterPath"/> represents an exclude filter.
@@ -286,5 +286,22 @@ namespace Nerdbank.GitVersioning
         {
             return this.RepoRelativePath;
         }
+
+        public bool Equals(FilterPath other)
+        {
+            if (ReferenceEquals(null, other)) return false;
+            if (ReferenceEquals(this, other)) return true;
+            return string.Equals(this.RepoRelativePath, other.RepoRelativePath, StringComparison.OrdinalIgnoreCase);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((FilterPath) obj);
+        }
+
+        public override int GetHashCode() => (this.RepoRelativePath is not null ? StringComparer.OrdinalIgnoreCase.GetHashCode(this.RepoRelativePath) : 0);
     }
 }

--- a/src/NerdBank.GitVersioning/Managed/ManagedGitExtensions.cs
+++ b/src/NerdBank.GitVersioning/Managed/ManagedGitExtensions.cs
@@ -32,7 +32,7 @@ namespace Nerdbank.GitVersioning.Managed
                 return 0;
             }
 
-            var tracker = new GitWalkTracker(context);
+            var tracker = new GitWalkTracker(context, null);
 
             var versionOptions = tracker.GetVersion(context.Commit.Value);
             if (versionOptions is null)
@@ -44,10 +44,14 @@ namespace Nerdbank.GitVersioning.Managed
                 baseVersion is not null ? SemanticVersion.Parse(baseVersion.ToString()) :
                 versionOptions.Version ?? SemVer0;
 
+            var pathFilters = versionOptions.HierarchicalVersion
+                ? new List<FilterPath>() {new FilterPath(context.RepoRelativeProjectDirectory, string.Empty)}
+                : versionOptions.PathFilters;
+
             var versionHeightPosition = versionOptions.VersionHeightPosition;
             if (versionHeightPosition.HasValue)
             {
-                int height = GetHeight(context, c => CommitMatchesVersion(c, baseSemVer, versionHeightPosition.Value, tracker));
+                int height = GetHeight(context, pathFilters, c => CommitMatchesVersion(c, baseSemVer, versionHeightPosition.Value, tracker));
                 return height;
             }
 
@@ -88,16 +92,17 @@ namespace Nerdbank.GitVersioning.Managed
         /// the specified commit and the most distant ancestor (inclusive).
         /// </summary>
         /// <param name="context">The git context.</param>
+        /// <param name="pathFilters">The path filters used to filtered walk through git commits.</param>
         /// <param name="continueStepping">
         /// A function that returns <c>false</c> when we reach a commit that
         /// should not be included in the height calculation.
         /// May be null to count the height to the original commit.
         /// </param>
         /// <returns>The height of the commit. Always a positive integer.</returns>
-        public static int GetHeight(ManagedGitContext context, Func<GitCommit, bool>? continueStepping = null)
+        public static int GetHeight(ManagedGitContext context, IReadOnlyList<FilterPath>? pathFilters, Func<GitCommit, bool>? continueStepping = null)
         {
             Verify.Operation(context.Commit.HasValue, "No commit is selected.");
-            var tracker = new GitWalkTracker(context);
+            var tracker = new GitWalkTracker(context, pathFilters);
             return GetCommitHeight(context.Repository, context.Commit.Value, tracker, continueStepping);
         }
 
@@ -152,29 +157,16 @@ namespace Nerdbank.GitVersioning.Managed
                     return false;
                 }
 
-                var versionOptions = tracker.GetVersion(commit);
-                var pathFilters = versionOptions?.PathFilters;
-
-                var includePaths =
-                    pathFilters
-                        ?.Where(filter => !filter.IsExclude)
-                        .Select(filter => filter.RepoRelativePath)
-                        .ToList();
-
-                var excludePaths = pathFilters?.Where(filter => filter.IsExclude).ToList();
-
-                var ignoreCase = repository.IgnoreCase;
-
                 int height = 1;
 
-                if (pathFilters is not null)
+                if (tracker.PathFilters.Count > 0)
                 {
                     var relevantCommit = true;
 
                     foreach (var parentId in commit.Parents)
                     {
                         var parent = repository.GetCommit(parentId);
-                        relevantCommit = IsRelevantCommit(repository, commit, parent, pathFilters);
+                        relevantCommit = IsRelevantCommit(repository, commit, parent, tracker.PathFilters);
 
                         // If the diff between this commit and any of its parents
                         // does not touch a path that we care about, don't bump the
@@ -305,11 +297,16 @@ namespace Nerdbank.GitVersioning.Managed
             private readonly Dictionary<GitObjectId, VersionOptions?> blobVersionCache = new Dictionary<GitObjectId, VersionOptions?>();
             private readonly Dictionary<GitObjectId, int> heights = new Dictionary<GitObjectId, int>();
             private readonly ManagedGitContext context;
+            private readonly IReadOnlyList<FilterPath> pathFilters;
 
-            internal GitWalkTracker(ManagedGitContext context)
+            internal GitWalkTracker(ManagedGitContext context, IReadOnlyList<FilterPath>? pathFilters)
             {
                 this.context = context;
+                this.pathFilters = pathFilters ?? new List<FilterPath>(0);
+
             }
+
+            internal IReadOnlyList<FilterPath> PathFilters => this.pathFilters;
 
             internal bool TryGetVersionHeight(GitCommit commit, out int height) => this.heights.TryGetValue(commit.Sha, out height);
 

--- a/src/NerdBank.GitVersioning/SemanticVersion.cs
+++ b/src/NerdBank.GitVersioning/SemanticVersion.cs
@@ -9,7 +9,7 @@
     /// Describes a version with an optional unstable tag.
     /// </summary>
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
-    public class SemanticVersion : IEquatable<SemanticVersion>
+    public class SemanticVersion : IEquatable<SemanticVersion>, ICloneable
     {
         /// <summary>
         /// The regular expression with capture groups for semantic versioning.
@@ -248,6 +248,10 @@
                 && this.Prerelease == other.Prerelease
                 && this.BuildMetadata == other.BuildMetadata;
         }
+
+        public SemanticVersion Clone() => new SemanticVersion((Version)this.Version.Clone(), this.Prerelease, this.BuildMetadata);
+
+        object ICloneable.Clone() => this.Clone();
 
         /// <summary>
         /// Tests whether two <see cref="SemanticVersion" /> instances are compatible enough that version height is not reset

--- a/src/NerdBank.GitVersioning/VersionOptions.cs
+++ b/src/NerdBank.GitVersioning/VersionOptions.cs
@@ -426,10 +426,10 @@ namespace Nerdbank.GitVersioning
         }
 
         /// <summary>
-        /// Gets or sets a value indicating whether the version in current directory structure is hierarchical and calculated independently per each sub-directory.
+        /// Gets or sets a value indicating whether the version in the current directory structure is hierarchical and calculated independently per each sub-directory.
         /// </summary>
         /// <remarks>
-        /// When this is <c>true</c>, the path filters are not applied and rather each sub-folder automatically applies itself as an only filter (included).
+        /// When this is <c>true</c>, the path filters are not applied, and rather each sub-folder automatically applies itself as an only filter (included).
         /// </remarks>
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         [System.ComponentModel.DefaultValue(null)]
@@ -441,7 +441,7 @@ namespace Nerdbank.GitVersioning
 
         /// <summary>
         /// Gets or sets a value indicating whether path filters are inherited from parent version configurations.
-        /// This is backward compatibility flag, if you want the behaviour of inheritance on path filters, you must to set the flag to true explicitly.
+        /// This is a backward compatibility flag, if you want the behaviour of inheritance on path filters, you must set the flag to true explicitly.
         /// </summary>
         /// <remarks>
         /// When this is <c>false</c>, the path filters are NOT inherited from parent configurations.

--- a/src/NerdBank.GitVersioning/version.schema.json
+++ b/src/NerdBank.GitVersioning/version.schema.json
@@ -192,12 +192,12 @@
           "uniqueItems": true
         },
         "inheritPathFilters": {
-          "description": "A value indicating whether path filters are inherited from parent version configurations. This is backward compatibility flag, if you want the behaviour of inheritance on path filters, you must to set the flag to true explicitly.",
+          "description": "A value indicating whether path filters are inherited from parent version configurations. This is a backward compatibility flag, if you want the behaviour of inheritance on path filters, you must set the flag to true explicitly.",
           "default": false
         },
         "hierarchicalVersion": {
           "type": "boolean",
-          "description": "A value indicating whether the version in current directory structure is hierarchical and calculated independently per each sub-directory. When this option is enabled the functionality of path filters is ignored and version of each folder is affected only by its own content.",
+          "description": "A value indicating whether the version in the current directory structure is hierarchical and calculated independently per each sub-directory. When this option has been enabled, the functionality of path filters is ignored, and the version of each folder is affected only by its own content.",
           "default": false
         }
       }

--- a/src/NerdBank.GitVersioning/version.schema.json
+++ b/src/NerdBank.GitVersioning/version.schema.json
@@ -190,6 +190,15 @@
             "pattern": "^(:\\^|:!|:/|[^:])"
           },
           "uniqueItems": true
+        },
+        "inheritPathFilters": {
+          "description": "A value indicating whether path filters are inherited from parent version configurations. This is backward compatibility flag, if you want the behaviour of inheritance on path filters, you must to set the flag to true explicitly.",
+          "default": false
+        },
+        "hierarchicalVersion": {
+          "type": "boolean",
+          "description": "A value indicating whether the version in current directory structure is hierarchical and calculated independently per each sub-directory. When this option is enabled the functionality of path filters is ignored and version of each folder is affected only by its own content.",
+          "default": false
         }
       }
     },


### PR DESCRIPTION
- inheritance of version options is more clear, and the process is more controllable
- added clear way how to control the inheritance of path filters (property )
  - `inheritPathFilters`: A value indicating whether path filters are inherited from parent version configurations. This is a backward compatibility flag, if you want the behaviour of inheritance on path filters, you must set the flag to true explicitly. 
- support for hierarchical versioning based on the folder structure
  - `hierarchicalVersion`: A value indicating whether the version in the current directory structure is hierarchical and calculated independently per each sub-directory. When this option has been enabled, the functionality of path filters is ignored, and the version of each folder is affected only by its own content.
  - When this flag is true, the path filters are not applied, and rather each sub-folder automatically applies itself as an only filter (included).