### PR TITLE
Count merge commits in path filtered height if any parent changed it

### DIFF
--- a/src/NerdBank.GitVersioning/LibGit2/LibGit2GitExtensions.cs
+++ b/src/NerdBank.GitVersioning/LibGit2/LibGit2GitExtensions.cs
@@ -433,8 +433,8 @@ namespace Nerdbank.GitVersioning.LibGit2
                             : includePaths;
 
                     // If the diff between this commit and any of its parents
-                    // does not touch a path that we care about, don't bump the
-                    // height.
+                    // touches a path that we care about, bump the height.
+                    // A no-parent commit is relevant if it introduces anything in the filtered path.
                     var relevantCommit =
                         commit.Parents.Any()
                             ? commit.Parents.Any(parent => ContainsRelevantChanges(commit.GetRepository().Diff


### PR DESCRIPTION
The managed git implementation had it correctly implemented, according to the code comments in the libgit2 implementation. But those code comments did not match the *code* in the libgit2 implementation. As a result, the managed git code did not match.

In this commit I correct the libgit2 impl code comments to describe what the code *actually* does. Then I fix the identical code comment and code in the managed git implementation to match.

Fixes #658