### PR TITLE
Cache version info to a file in quickbuild

### DIFF
--- a/doc/quickbuild.md
+++ b/doc/quickbuild.md
@@ -4,8 +4,6 @@ Nerdbank.GitVersioning supports the Microsoft-internal quickbuild/cloudbuild too
 
 It works out of the box, but each project will recompute the version, which may accumulate to a significant increase in overall build time.
 
-🚧 A future version of Nerdbank.GitVersioning will cache version information as a file so that the following instructions will be effective. 🚧
-
 To calculate the version just once for an entire build, a few manual steps are required.
 
 1. Create this project in your repo. The suggested location is `VersionGeneration/VersionGeneration.msbuildproj`.

--- a/src/Nerdbank.GitVersioning.Tasks/build/Nerdbank.GitVersioning.Inner.targets
+++ b/src/Nerdbank.GitVersioning.Tasks/build/Nerdbank.GitVersioning.Inner.targets
@@ -19,6 +19,8 @@
       BuildMetadata="$(BuildMetadata.Replace(',',';'))"
       DefaultPublicRelease="$(PublicRelease)"
       ProjectDirectory="$(GitVersionBaseDirectory)"
+      IntermediateOutputPath="$(IntermediateOutputPath)"
+      PreferCachedInfoOverCurrentData="$(NBGV_PreferCachedInfoOverCurrentData)"
       GitRepoRoot="$(GitRepoRoot)"
       ProjectPathRelativeToGitRepoRoot="$(ProjectPathRelativeToGitRepoRoot)"
       OverrideBuildNumberOffset="$(OverrideBuildNumberOffset)"

--- a/src/Nerdbank.GitVersioning.Tasks/build/Nerdbank.GitVersioning.props
+++ b/src/Nerdbank.GitVersioning.Tasks/build/Nerdbank.GitVersioning.props
@@ -16,5 +16,8 @@
          Learn more at :/doc/quickbuild.md.
          -->
     <NBGV_CachingProjectReference Condition=" '$(NBGV_CachingProjectReference)' == '' ">$(MSBuildThisFileDirectory)PrivateP2PCaching.proj</NBGV_CachingProjectReference>
+
+    <NBGV_PreferCachedInfoOverCurrentData Condition=" '$(NBGV_PreferCachedInfoOverCurrentData)' == '' and '$(QBuild)' == '1' ">true</NBGV_PreferCachedInfoOverCurrentData>
+    <NBGV_PreferCachedInfoOverCurrentData Condition=" '$(NBGV_PreferCachedInfoOverCurrentData)' == '' ">false</NBGV_PreferCachedInfoOverCurrentData>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
- [ ] Figure out how to re-run the VersionGeneration target when `.git\HEAD` changes, but not obliterate the cache for all dependency projects on account of a HEAD move.