### PR TITLE
Fix `dotnet publish` on an app that uses NB.GV

### DIFF
--- a/src/Nerdbank.GitVersioning.Tasks/build/PrivateP2PCaching.proj
+++ b/src/Nerdbank.GitVersioning.Tasks/build/PrivateP2PCaching.proj
@@ -7,6 +7,7 @@
   <Target Name="GetTargetFrameworks" />
   <Target Name="GetNativeManifest" />
   <Target Name="GetCopyToOutputDirectoryItems" />
+  <Target Name="GetCopyToPublishDirectoryItems" />
   <Target Name="GetTargetFrameworksWithPlatformForSingleTargetFramework" />
 
 </Project>


### PR DESCRIPTION
Fixes #671