### PR TITLE
Add retry to SetCloudBuildVariable method in VisualStudioTeamServices

### DIFF
--- a/src/NerdBank.GitVersioning/CloudBuildServices/VisualStudioTeamServices.cs
+++ b/src/NerdBank.GitVersioning/CloudBuildServices/VisualStudioTeamServices.cs
@@ -33,7 +33,8 @@
 
         public IReadOnlyDictionary<string, string> SetCloudBuildVariable(string name, string value, TextWriter stdout, TextWriter stderr)
         {
-            (stdout ?? Console.Out).WriteLine($"##vso[task.setvariable variable={name};]{value}");
+            Utilities.FileOperationWithRetry(() =>
+                (stdout ?? Console.Out).WriteLine($"##vso[task.setvariable variable={name};]{value}"));
             return GetDictionaryFor(name, value);
         }
 


### PR DESCRIPTION
Adds retry to the `SetCloudBuildVariable` method in the `VisualStudioTeamServices`.

The reason for this is to fix errors when building using `dotnet` CLI in Azure DevOps.

```
The "Nerdbank.GitVersioning.Tasks.SetCloudBuildVariables" task failed unexpectedly. [C:\agent04\_work\1\s\src\Demo.Common.Abstractions\Demo.Common.Abstractions.csproj]
System.IO.IOException: No process is on the other end of the pipe. [C:\agent04\_work\1\s\src\Demo.Common.Abstractions\Demo.Common.Abstractions.csproj]
   at System.ConsolePal.WindowsConsoleStream.Write(Byte[] buffer, Int32 offset, Int32 count) [C:\agent04\_work\1\s\src\Demo.Common.Abstractions\Demo.Common.Abstractions.csproj]
   at System.IO.StreamWriter.Flush(Boolean flushStream, Boolean flushEncoder) [C:\agent04\_work\1\s\src\Demo.Common.Abstractions\Demo.Common.Abstractions.csproj]
   at System.IO.StreamWriter.WriteLine(String value) [C:\agent04\_work\1\s\src\Demo.Common.Abstractions\Demo.Common.Abstractions.csproj]
   at System.IO.TextWriter.SyncTextWriter.WriteLine(String value) [C:\agent04\_work\1\s\src\Demo.Common.Abstractions\Demo.Common.Abstractions.csproj]
   at Nerdbank.GitVersioning.CloudBuildServices.VisualStudioTeamServices.SetCloudBuildVariable(String name, String value, TextWriter stdout, TextWriter stderr) [C:\agent04\_work\1\s\src\Demo.Common.Abstractions\Demo.Common.Abstractions.csproj]
   at Nerdbank.GitVersioning.Tasks.SetCloudBuildVariables.Execute() [C:\agent04\_work\1\s\src\Demo.Common.Abstractions\Demo.Common.Abstractions.csproj]
   at Microsoft.Build.BackEnd.TaskExecutionHost.Microsoft.Build.BackEnd.ITaskExecutionHost.Execute() [C:\agent04\_work\1\s\src\Demo.Common.Abstractions\Demo.Common.Abstractions.csproj]
   at Microsoft.Build.BackEnd.TaskBuilder.ExecuteInstantiatedTask(ITaskExecutionHost taskExecutionHost, TaskLoggingContext taskLoggingContext, TaskHost taskHost, ItemBucket bucket, TaskExecutionMode howToExecuteTask) [C:\agent04\_work\1\s\src\Demo.Common.Abstractions\Demo.Common.Abstractions.csproj]
##[error]The "Nerdbank.GitVersioning.Tasks.SetCloudBuildVariables" task failed unexpectedly.
```