### PR TITLE
Fixes `nbgv get-commits` to require version matching

### DIFF
--- a/src/NerdBank.GitVersioning.Tests/GitExtensionsTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/GitExtensionsTests.cs
@@ -129,6 +129,18 @@ public partial class GitExtensionsTests : RepoTestBase
             LibGit2GitExtensions.GetCommitsFromVersion(this.Context, new Version(1, 2, 3)).OrderBy(c => c.Sha));
     }
 
+    [Fact]
+    public void GetCommitsFromVersion_WithMajorMinorChecks()
+    {
+        Commit v1_0_50 = this.WriteVersionFile(new VersionOptions { Version = SemanticVersion.Parse("1.0.50-preview.{height}") });
+        Commit v1_1_50 = this.WriteVersionFile(new VersionOptions { Version = SemanticVersion.Parse("1.1.50-preview.{height}") });
+
+        Assert.Empty(LibGit2GitExtensions.GetCommitsFromVersion(this.Context, new Version(1, 0)));
+        Assert.Empty(LibGit2GitExtensions.GetCommitsFromVersion(this.Context, new Version(1, 0, 49)));
+        Assert.Equal(v1_0_50, Assert.Single(LibGit2GitExtensions.GetCommitsFromVersion(this.Context, new Version(1, 0, 50))));
+        Assert.Equal(v1_1_50, Assert.Single(LibGit2GitExtensions.GetCommitsFromVersion(this.Context, new Version(1, 1, 50))));
+    }
+
     [Theory]
     [InlineData("2.2", "2.2-alpha.{height}", 1, 1, true)]
     [InlineData("2.2", "2.3", 1, 1, true)]

--- a/src/NerdBank.GitVersioning/LibGit2/LibGit2GitExtensions.cs
+++ b/src/NerdBank.GitVersioning/LibGit2/LibGit2GitExtensions.cs
@@ -174,7 +174,7 @@ namespace Nerdbank.GitVersioning.LibGit2
             var tracker = new GitWalkTracker(context);
             var possibleCommits = from commit in GetCommitsReachableFromRefs(context.Repository)
                                   let commitVersionOptions = tracker.GetVersion(commit)
-                                  where commitVersionOptions is not null
+                                  where commitVersionOptions?.Version?.IsMatchingVersion(version) is true
                                   where !IsCommitIdMismatch(version, commitVersionOptions, commit)
                                   where !IsVersionHeightMismatch(version, commitVersionOptions, commit, tracker)
                                   select commit;

--- a/src/NerdBank.GitVersioning/VersionOptions.cs
+++ b/src/NerdBank.GitVersioning/VersionOptions.cs
@@ -433,24 +433,7 @@ namespace Nerdbank.GitVersioning
         /// Gets the position in a computed version that the first 16 bits of a git commit ID should appear, if any.
         /// </summary>
         [JsonIgnore]
-        internal SemanticVersion.Position? GitCommitIdPosition
-        {
-            get
-            {
-                // We can only store the git commit ID info after there was a place to put the version height.
-                // We don't want to store the commit ID (which is effectively a random integer) in the revision slot
-                // if the version height does not appear, or only appears later (in the -prerelease tag) since that
-                // would mess up version ordering.
-                if (this.VersionHeightPosition == SemanticVersion.Position.Build)
-                {
-                    return SemanticVersion.Position.Revision;
-                }
-                else
-                {
-                    return null;
-                }
-            }
-        }
+        internal SemanticVersion.Position? GitCommitIdPosition => this.version?.GitCommitIdPosition;
 
         /// <summary>
         /// Gets the debugger display for this instance.


### PR DESCRIPTION
We previously were only looking at version height and (optional) commit ID. We were (amazingly enough) not bothering to look at the major.minor version specified in the version.json file.