### PR TITLE
GitHubActions cloud build exception on local machine

### DIFF
--- a/src/NerdBank.GitVersioning/CloudBuildServices/GitHubActions.cs
+++ b/src/NerdBank.GitVersioning/CloudBuildServices/GitHubActions.cs
@@ -28,7 +28,16 @@
 
         public IReadOnlyDictionary<string, string> SetCloudBuildVariable(string name, string value, TextWriter stdout, TextWriter stderr)
         {
-            Utilities.FileOperationWithRetry(() => File.AppendAllText(EnvironmentFile, $"{Environment.NewLine}{name}={value}{Environment.NewLine}"));
+            if (EnvironmentFile is not null)
+            {
+                Utilities.FileOperationWithRetry(() =>
+                    File.AppendAllText(EnvironmentFile, $"{Environment.NewLine}{name}={value}{Environment.NewLine}"));
+            }
+            else
+            {
+                (stdout ?? Console.Out).WriteLine($"{name}={value}");
+            }
+
             return GetDictionaryFor(name, value);
         }
 


### PR DESCRIPTION
If I run the following command on my development machine (outside of a Github Actions Workflow):

    nbgv cloud -s GitHubActions -a -p src

I get the following exception:

> Unhandled exception: System.Reflection.TargetInvocationException:
> Exception has been thrown by the target of an invocation.
> ---> System.ArgumentNullException: Value cannot be null. (Parameter 'path')
>   at System.IO.File.AppendAllText(String path, String contents)

The `EnvironmentFile` variable is null because `GITHUB_ENV` does not
exist on a local machine. Instead, simply write to console so the user
can see the output of the cloud build variables (which I believe is the
intention when a developer runs this locally).