### PR TITLE
Update to .NET 6, Update libgit2sharp to include macOS ARM64

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,7 +36,7 @@ stages:
       matrix:
         linux:
           imageName: 'ubuntu-20.04'
-          testModifier:
+          testModifier: -f net6.0
         windows:
           imageName: 'windows-2019'
           testModifier:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,7 +36,7 @@ stages:
       matrix:
         linux:
           imageName: 'ubuntu-20.04'
-          testModifier: -f net6.0
+          testModifier:
         windows:
           imageName: 'windows-2019'
           testModifier:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -56,10 +56,10 @@ stages:
       displayName: Configure git commit author for testing
 
     - task: UseDotNet@2
-      displayName: Install .NET Core 6.0.100 SDK
+      displayName: Install .NET Core 3.1 runtime
       inputs:
-        packageType: sdk
-        version: 6.0.100
+        packageType: runtime
+        version: 3.1.x
 
     - task: UseDotNet@2
       displayName: Install .NET Core 5.0.401 SDK
@@ -68,10 +68,10 @@ stages:
         version: 5.0.401
 
     - task: UseDotNet@2
-      displayName: Install .NET Core 3.1 runtime
+      displayName: Install .NET Core 6.0.100 SDK
       inputs:
-        packageType: runtime
-        version: 3.1.x
+        packageType: sdk
+        version: 6.0.100
 
     - pwsh: |
         Invoke-WebRequest -Uri "https://dot.net/v1/dotnet-install.ps1" -OutFile dotnet-install.ps1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -75,10 +75,10 @@ stages:
 
     - pwsh: |
         Invoke-WebRequest -Uri "https://dot.net/v1/dotnet-install.ps1" -OutFile dotnet-install.ps1
-        & .\dotnet-install.ps1 -Architecture x86 -Version 5.0.401 -InstallDir "C:\Program Files (x86)\dotnet\" -NoPath -Verbose
-        & .\dotnet-install.ps1 -Architecture x86 -Version 6.0.100 -InstallDir "C:\Program Files (x86)\dotnet\" -NoPath -Verbose
+        & .\dotnet-install.ps1 -Architecture x86 -Channel 5.0 -InstallDir "C:\Program Files (x86)\dotnet\" -NoPath -Verbose
         & .\dotnet-install.ps1 -Architecture x86 -Channel 3.1 -InstallDir "C:\Program Files (x86)\dotnet\" -NoPath -Verbose
-      displayName: Install 32-bit .NET Core SDK 6.0.100, 3.1
+        & .\dotnet-install.ps1 -Architecture x86 -Version 6.0.100 -InstallDir "C:\Program Files (x86)\dotnet\" -NoPath -Verbose
+      displayName: Install 32-bit .NET Core SDK and runtimes
       condition: ne(variables['dotnet32'], '')
 
     - script: dotnet --info

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -56,10 +56,10 @@ stages:
       displayName: Configure git commit author for testing
 
     - task: UseDotNet@2
-      displayName: Install .NET Core 5.0.401 SDK
+      displayName: Install .NET Core 6.0.100 SDK
       inputs:
         packageType: sdk
-        version: 5.0.401
+        version: 6.0.100
 
     - task: UseDotNet@2
       displayName: Install .NET Core 3.1 runtime
@@ -69,9 +69,9 @@ stages:
 
     - pwsh: |
         Invoke-WebRequest -Uri "https://dot.net/v1/dotnet-install.ps1" -OutFile dotnet-install.ps1
-        & .\dotnet-install.ps1 -Architecture x86 -Version 5.0.401 -InstallDir "C:\Program Files (x86)\dotnet\" -NoPath -Verbose
+        & .\dotnet-install.ps1 -Architecture x86 -Version 6.0.100 -InstallDir "C:\Program Files (x86)\dotnet\" -NoPath -Verbose
         & .\dotnet-install.ps1 -Architecture x86 -Channel 3.1 -InstallDir "C:\Program Files (x86)\dotnet\" -NoPath -Verbose
-      displayName: Install 32-bit .NET Core SDK 5.0.401, 3.1
+      displayName: Install 32-bit .NET Core SDK 6.0.100, 3.1
       condition: ne(variables['dotnet32'], '')
 
     - script: dotnet --info
@@ -332,7 +332,7 @@ stages:
       displayName: Install .NET Core 5.0.401 SDK
       inputs:
         packageType: sdk
-        version: 5.0.401
+        version: 6.0.100
     - script: dotnet --info
       displayName: Show dotnet SDK info
     - bash: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,7 +36,7 @@ stages:
       matrix:
         linux:
           imageName: 'ubuntu-20.04'
-          testModifier: -f net5.0
+          testModifier: -f net6.0
         windows:
           imageName: 'windows-2019'
           testModifier:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,6 +62,12 @@ stages:
         version: 6.0.100
 
     - task: UseDotNet@2
+      displayName: Install .NET Core 5.0.401 SDK
+      inputs:
+        packageType: sdk
+        version: 5.0.401
+
+    - task: UseDotNet@2
       displayName: Install .NET Core 3.1 runtime
       inputs:
         packageType: runtime
@@ -69,6 +75,7 @@ stages:
 
     - pwsh: |
         Invoke-WebRequest -Uri "https://dot.net/v1/dotnet-install.ps1" -OutFile dotnet-install.ps1
+        & .\dotnet-install.ps1 -Architecture x86 -Version 5.0.401 -InstallDir "C:\Program Files (x86)\dotnet\" -NoPath -Verbose
         & .\dotnet-install.ps1 -Architecture x86 -Version 6.0.100 -InstallDir "C:\Program Files (x86)\dotnet\" -NoPath -Verbose
         & .\dotnet-install.ps1 -Architecture x86 -Channel 3.1 -InstallDir "C:\Program Files (x86)\dotnet\" -NoPath -Verbose
       displayName: Install 32-bit .NET Core SDK 6.0.100, 3.1
@@ -330,6 +337,11 @@ stages:
         version: 3.1.x
     - task: UseDotNet@2
       displayName: Install .NET Core 5.0.401 SDK
+      inputs:
+        packageType: sdk
+        version: 5.0.401
+    - task: UseDotNet@2
+      displayName: Install .NET Core 6.0.100 SDK
       inputs:
         packageType: sdk
         version: 6.0.100

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,7 +39,7 @@ stages:
           testModifier: -f net6.0
         windows:
           imageName: 'windows-2019'
-          testModifier:
+          testModifier: -f net6.0
           dotnet32: "\"C:\\Program Files (x86)\\dotnet\\dotnet.exe\""
     variables:
     - ${{ if eq(variables['System.TeamFoundationCollectionUri'], 'https://dev.azure.com/andrewarnott/') }}:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -138,7 +138,7 @@ stages:
 
     - script: >
         $(dotnet32) test NerdBank.GitVersioning.Tests
-        --no-build $(testModifier)
+        --no-build
         -c $(BuildConfiguration)
         --filter "TestCategory!=FailsOnAzurePipelines"
         --logger "trx;LogFileName=$(Build.ArtifactStagingDirectory)/TestLogs/TestResults.x86.trx"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -359,7 +359,7 @@ stages:
       workingDirectory: src/
       displayName: Build in Release mode
     - script: |
-        dotnet run -c Release -f netcoreapp3.1 -- --filter GetVersionBenchmarks --artifacts $(Build.ArtifactStagingDirectory)/benchmarks/packed/$(imageName)
+        dotnet run -c Release -f net6.0 -- --filter GetVersionBenchmarks --artifacts $(Build.ArtifactStagingDirectory)/benchmarks/packed/$(imageName)
       workingDirectory: src/NerdBank.GitVersioning.Benchmarks
       displayName: Run benchmarks (packed)
     - bash: |
@@ -376,7 +376,7 @@ stages:
         git unpack-objects < .git/objects/pack/*.pack
       displayName: Unpack Git repositories
     - script: |
-        dotnet run -c Release -f netcoreapp3.1 -- --filter GetVersionBenchmarks --artifacts $(Build.ArtifactStagingDirectory)/benchmarks/unpacked/$(imageName)
+        dotnet run -c Release -f net6.0 -- --filter GetVersionBenchmarks --artifacts $(Build.ArtifactStagingDirectory)/benchmarks/unpacked/$(imageName)
       workingDirectory: src/NerdBank.GitVersioning.Benchmarks
       displayName: Run benchmarks (unpacked)
     - task: PublishBuildArtifacts@1

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "5.0.401",
+    "version": "6.0.100",
     "rollForward": "patch",
     "allowPrerelease": false
   }

--- a/src/Cake.GitVersioning.Tests/Cake.GitVersioning.Tests.csproj
+++ b/src/Cake.GitVersioning.Tests/Cake.GitVersioning.Tests.csproj
@@ -15,7 +15,7 @@
     <ProjectReference Include="..\NerdBank.GitVersioning\NerdBank.GitVersioning.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="Nerdbank.GitVersioning.LKG" Version="3.4.173-alpha" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">

--- a/src/Cake.GitVersioning.Tests/Cake.GitVersioning.Tests.csproj
+++ b/src/Cake.GitVersioning.Tests/Cake.GitVersioning.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;net461</TargetFrameworks>
+    <TargetFrameworks>net6.0;net5.0;net461</TargetFrameworks>
     <SignAssembly>false</SignAssembly>
     <IsTestProject>true</IsTestProject>
     <IsPackable>false</IsPackable>

--- a/src/Cake.GitVersioning/Cake.GitVersioning.csproj
+++ b/src/Cake.GitVersioning/Cake.GitVersioning.csproj
@@ -41,7 +41,8 @@
     <None Include="$(LibGit2SharpNativeBinaries)runtimes\**\*.*" Pack="true" PackagePath="lib\netstandard2.0\lib\" LinkBase="lib" />
 
     <!-- Additional copies to work around DllNotFoundException on Mono (https://github.com/AArnott/Nerdbank.GitVersioning/issues/222) -->
-    <None Include="$(LibGit2SharpNativeBinaries)runtimes\osx\native\*.dylib" Pack="true" PackagePath="lib\netstandard2.0\lib\osx\" LinkBase="lib\osx" />
+    <None Include="$(LibGit2SharpNativeBinaries)runtimes\osx-x64\native\*.dylib" Pack="true" PackagePath="lib\netstandard2.0\lib\osx\x86_64\" LinkBase="lib\osx\x86_64" />
+    <None Include="$(LibGit2SharpNativeBinaries)runtimes\osx-arm64\native\*.dylib" Pack="true" PackagePath="lib\netstandard2.0\lib\osx\arm_64\" LinkBase="lib\arm64\arm_64" />
     <None Include="$(LibGit2SharpNativeBinaries)runtimes\linux-x64\native\*.so" Pack="true" PackagePath="lib\netstandard2.0\lib\linux\x86_64\" LinkBase="lib\linux\x86_64" />
     <None Include="$(LibGit2SharpNativeBinaries)runtimes\win-x64\native\*.dll" Pack="true" PackagePath="lib\netstandard2.0\lib\win32\x64\" LinkBase="lib\win32\x64" />
     <None Include="$(LibGit2SharpNativeBinaries)runtimes\win-x86\native\*.dll" Pack="true" PackagePath="lib\netstandard2.0\lib\win32\x86\" LinkBase="lib\win32\x86" />

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -21,7 +21,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- LibGit2Sharp Native Binary version - used in both main project and Cake addin -->
-    <LibGit2SharpNativeVersion>2.0.312</LibGit2SharpNativeVersion>
+    <LibGit2SharpNativeVersion>2.0.315-alpha.0.9</LibGit2SharpNativeVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="3.11.0" PrivateAssets="all" />

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -24,10 +24,10 @@
     <LibGit2SharpNativeVersion>2.0.315-alpha.0.9</LibGit2SharpNativeVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="3.11.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.0.1" PrivateAssets="all" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-    <PackageReference Include="CSharpIsNullAnalyzer" Version="0.1.288-beta">
+    <PackageReference Include="CSharpIsNullAnalyzer" Version="0.1.300">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/src/NerdBank.GitVersioning.Benchmarks/Nerdbank.GitVersioning.Benchmarks.csproj
+++ b/src/NerdBank.GitVersioning.Benchmarks/Nerdbank.GitVersioning.Benchmarks.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net461</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/NerdBank.GitVersioning.Benchmarks/Nerdbank.GitVersioning.Benchmarks.csproj
+++ b/src/NerdBank.GitVersioning.Benchmarks/Nerdbank.GitVersioning.Benchmarks.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net461</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/NerdBank.GitVersioning.Tests/ManagedGit/GitPackTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/ManagedGit/GitPackTests.cs
@@ -5,6 +5,7 @@ using System.Security.Cryptography;
 using Nerdbank.GitVersioning;
 using Nerdbank.GitVersioning.ManagedGit;
 using Xunit;
+using ZLibStream = Nerdbank.GitVersioning.ManagedGit.ZLibStream;
 
 namespace ManagedGit
 {

--- a/src/NerdBank.GitVersioning.Tests/ManagedGit/ZLibStreamTest.cs
+++ b/src/NerdBank.GitVersioning.Tests/ManagedGit/ZLibStreamTest.cs
@@ -5,6 +5,7 @@ using System.Security.Cryptography;
 using System.Text;
 using Nerdbank.GitVersioning.ManagedGit;
 using Xunit;
+using ZLibStream = Nerdbank.GitVersioning.ManagedGit.ZLibStream;
 
 namespace ManagedGit
 {

--- a/src/NerdBank.GitVersioning.Tests/NerdBank.GitVersioning.Tests.csproj
+++ b/src/NerdBank.GitVersioning.Tests/NerdBank.GitVersioning.Tests.csproj
@@ -37,7 +37,7 @@
     <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
     <PackageReference Include="Microsoft.Build" Version="15.1.548" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.1.548" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.Build.Locator" Version="1.2.6" />
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.4.1" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.9.0" />
     <PackageReference Include="Xunit.Combinatorial" Version="1.2.7" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/src/NerdBank.GitVersioning.Tests/NerdBank.GitVersioning.Tests.csproj
+++ b/src/NerdBank.GitVersioning.Tests/NerdBank.GitVersioning.Tests.csproj
@@ -32,6 +32,7 @@
     <ProjectReference Include="..\NerdBank.GitVersioning\NerdBank.GitVersioning.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="Newtonsoft.Json.Schema" Version="3.0.10" />
     <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
     <PackageReference Include="Microsoft.Build" Version="15.1.548" ExcludeAssets="runtime" />
@@ -43,7 +44,7 @@
     <PackageReference Include="coverlet.collector" Version="1.3.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" />
     <PackageReference Include="Nerdbank.GitVersioning.LKG" Version="3.4.173-alpha" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/src/NerdBank.GitVersioning.Tests/NerdBank.GitVersioning.Tests.csproj
+++ b/src/NerdBank.GitVersioning.Tests/NerdBank.GitVersioning.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;net461</TargetFrameworks>
+    <TargetFrameworks>net6.0;net5.0;net461</TargetFrameworks>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <DebugType>full</DebugType>

--- a/src/NerdBank.GitVersioning.Tests/NerdBank.GitVersioning.Tests.csproj
+++ b/src/NerdBank.GitVersioning.Tests/NerdBank.GitVersioning.Tests.csproj
@@ -33,7 +33,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json.Schema" Version="3.0.10" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
     <PackageReference Include="Microsoft.Build" Version="15.1.548" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.1.548" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.Build.Locator" Version="1.2.6" />
@@ -41,7 +41,8 @@
     <PackageReference Include="Xunit.Combinatorial" Version="1.2.7" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="coverlet.collector" Version="1.3.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.10.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.0.1" />
     <PackageReference Include="Nerdbank.GitVersioning.LKG" Version="3.4.173-alpha" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>

--- a/src/NerdBank.GitVersioning.Tests/NerdBank.GitVersioning.Tests.csproj
+++ b/src/NerdBank.GitVersioning.Tests/NerdBank.GitVersioning.Tests.csproj
@@ -42,7 +42,6 @@
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="coverlet.collector" Version="1.3.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.0.1" />
     <PackageReference Include="Nerdbank.GitVersioning.LKG" Version="3.4.173-alpha" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>

--- a/src/NerdBank.GitVersioning/LibGit2/LibGit2GitExtensions.cs
+++ b/src/NerdBank.GitVersioning/LibGit2/LibGit2GitExtensions.cs
@@ -173,7 +173,7 @@ namespace Nerdbank.GitVersioning.LibGit2
             }
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
-                return Path.Combine(basePath, "lib", "osx");
+                return Path.Combine(basePath, "lib", "osx", RuntimeInformation.OSArchitecture == Architecture.Arm64 ? "arm_64" : "x86_64");
             }
 
             return null;

--- a/src/NerdBank.GitVersioning/NerdBank.GitVersioning.csproj
+++ b/src/NerdBank.GitVersioning/NerdBank.GitVersioning.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Nullable" Version="1.3.0" PrivateAssets="all" />
     <PackageReference Include="Validation" Version="2.5.5-beta" />
     <PackageReference Include="Nerdbank.GitVersioning.LKG" Version="3.4.173-alpha" />
-    <PackageReference Include="System.Text.Json" Version="6.0.0" />
+    <PackageReference Include="System.Text.Json" Version="4.7.2" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\Shared\**\*.cs" LinkBase="Shared" />

--- a/src/NerdBank.GitVersioning/NerdBank.GitVersioning.csproj
+++ b/src/NerdBank.GitVersioning/NerdBank.GitVersioning.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Nullable" Version="1.3.0" PrivateAssets="all" />
     <PackageReference Include="Validation" Version="2.5.5-beta" />
     <PackageReference Include="Nerdbank.GitVersioning.LKG" Version="3.4.173-alpha" />
-    <PackageReference Include="System.Text.Json" Version="4.7.2" />
+    <PackageReference Include="System.Text.Json" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\Shared\**\*.cs" LinkBase="Shared" />

--- a/src/Nerdbank.GitVersioning.Tasks/Nerdbank.GitVersioning.nuspec
+++ b/src/Nerdbank.GitVersioning.Tasks/Nerdbank.GitVersioning.nuspec
@@ -32,12 +32,13 @@ IMPORTANT: The 3.x release may produce a different version height than prior maj
     <file src="$LibGit2SharpNativeBinaries$runtimes\**" target="build\runtimes\" />
 
     <!-- Additional copies to work around DllNotFoundException on Mono (https://github.com/dotnet/Nerdbank.GitVersioning/issues/222) -->
-    <file src="$LibGit2SharpNativeBinaries$runtimes\osx\native\libgit2-6777db8.dylib" target="build\MSBuildFull\lib\osx\libgit2-6777db8.dylib" />
-    <file src="$LibGit2SharpNativeBinaries$runtimes\linux-x64\native\libgit2-6777db8.so" target="build\MSBuildFull\lib\linux-x64\libgit2-6777db8.so" />
+    <file src="$LibGit2SharpNativeBinaries$runtimes\osx-x64\native\libgit2-b7bad55.dylib" target="build\MSBuildFull\lib\osx-x64\libgit2-b7bad55.dylib" />
+    <file src="$LibGit2SharpNativeBinaries$runtimes\osx-arm64\native\libgit2-b7bad55.dylib" target="build\MSBuildFull\lib\osx-arm64\libgit2-b7bad55.dylib" />
+    <file src="$LibGit2SharpNativeBinaries$runtimes\linux-x64\native\libgit2-b7bad55.so" target="build\MSBuildFull\lib\linux-x64\libgit2-b7bad55.so" />
 
     <!-- Additional copies to work with our own ps1 scripts (https://github.com/dotnet/Nerdbank.GitVersioning/issues/248) -->
-    <file src="$LibGit2SharpNativeBinaries$runtimes\win-x64\native\git2-6777db8.dll" target="build\MSBuildFull\lib\win32\x64\git2-6777db8.dll" />
-    <file src="$LibGit2SharpNativeBinaries$runtimes\win-x86\native\git2-6777db8.dll" target="build\MSBuildFull\lib\win32\x86\git2-6777db8.dll" />
+    <file src="$LibGit2SharpNativeBinaries$runtimes\win-x64\native\git2-b7bad55.dll" target="build\MSBuildFull\lib\win32\x64\git2-b7bad55.dll" />
+    <file src="$LibGit2SharpNativeBinaries$runtimes\win-x86\native\git2-b7bad55.dll" target="build\MSBuildFull\lib\win32\x86\git2-b7bad55.dll" />
 
     <file src="$LibGit2SharpNativeBinaries$libgit2\LibGit2Sharp.dll.config" target="build\MSBuildCore\LibGit2Sharp.dll.config" />
     <file src="$BaseOutputPath$netcoreapp3.1\LibGit2Sharp.dll" target="build\MSBuildCore\LibGit2Sharp.dll" />


### PR DESCRIPTION
In order to use GitVersioning with the .NET 6 SDK on the M1, we need to update libgit2sharp to the newest release, which includes macOS ARM64 (https://github.com/libgit2/libgit2sharp.nativebinaries/pull/132) support.

So, in order to use that, we also need to update the base library to include .NET 6. 

I also had to include some using fixes for the tests, since it got an ambiguous reference between 'System.IO.Compression.ZLibStream' and 'Nerdbank.GitVersioning.ManagedGit.ZLibStream'.

