### PR TITLE
Rename `GenerateAssemblyVersionInfo` msbuild target to `GenerateAssemblyNBGVVersionInfo`

### DIFF
--- a/src/NerdBank.GitVersioning.Tests/BuildIntegrationTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/BuildIntegrationTests.cs
@@ -1264,7 +1264,7 @@ public abstract class BuildIntegrationTests : RepoTestBase, IClassFixture<MSBuil
         internal const string GetBuildVersion = "GetBuildVersion";
         internal const string GetNuGetPackageVersion = "GetNuGetPackageVersion";
         internal const string GenerateAssemblyNBGVVersionInfo = "GenerateAssemblyNBGVVersionInfo";
-        internal const string GenerateNativeVersionInfo = "GenerateNativeVersionInfo";
+        internal const string GenerateNativeNBGVVersionInfo = "GenerateNativeNBGVVersionInfo";
     }
 
     private static class Properties

--- a/src/NerdBank.GitVersioning.Tests/BuildIntegrationTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/BuildIntegrationTests.cs
@@ -897,7 +897,7 @@ public abstract class BuildIntegrationTests : RepoTestBase, IClassFixture<MSBuil
         this.testProject.AddProperty("DelaySign", delaySigned.ToString());
 
         this.WriteVersionFile();
-        var result = await this.BuildAsync(Targets.GenerateAssemblyVersionInfo, logVerbosity: LoggerVerbosity.Minimal);
+        var result = await this.BuildAsync(Targets.GenerateAssemblyNBGVVersionInfo, logVerbosity: LoggerVerbosity.Minimal);
         string versionCsContent = File.ReadAllText(
             Path.GetFullPath(
                 Path.Combine(
@@ -951,7 +951,7 @@ public abstract class BuildIntegrationTests : RepoTestBase, IClassFixture<MSBuil
         propertyGroup.AddProperty("Language", "NoCodeDOMProviderForThisLanguage");
 
         this.WriteVersionFile();
-        var result = await this.BuildAsync(Targets.GenerateAssemblyVersionInfo, logVerbosity: LoggerVerbosity.Minimal, assertSuccessfulBuild: false);
+        var result = await this.BuildAsync(Targets.GenerateAssemblyNBGVVersionInfo, logVerbosity: LoggerVerbosity.Minimal, assertSuccessfulBuild: false);
         Assert.Equal(BuildResultCode.Failure, result.BuildResult.OverallResult);
         string versionCsFilePath = Path.Combine(this.projectDirectory, result.BuildResult.ProjectStateAfterBuild.GetPropertyValue("VersionSourceFile"));
         Assert.False(File.Exists(versionCsFilePath));
@@ -968,10 +968,10 @@ public abstract class BuildIntegrationTests : RepoTestBase, IClassFixture<MSBuil
         var propertyGroup = this.testProject.CreatePropertyGroupElement();
         this.testProject.AppendChild(propertyGroup);
         propertyGroup.AddProperty("Language", "NoCodeDOMProviderForThisLanguage");
-        propertyGroup.AddProperty(Targets.GenerateAssemblyVersionInfo, "false");
+        propertyGroup.AddProperty(Properties.GenerateAssemblyVersionInfo, "false");
 
         this.WriteVersionFile();
-        var result = await this.BuildAsync(Targets.GenerateAssemblyVersionInfo, logVerbosity: LoggerVerbosity.Minimal);
+        var result = await this.BuildAsync(Targets.GenerateAssemblyNBGVVersionInfo, logVerbosity: LoggerVerbosity.Minimal);
         string versionCsFilePath = Path.Combine(this.projectDirectory, result.BuildResult.ProjectStateAfterBuild.GetPropertyValue("VersionSourceFile"));
         Assert.False(File.Exists(versionCsFilePath));
         Assert.Empty(result.LoggedEvents.OfType<BuildErrorEventArgs>());
@@ -991,7 +991,7 @@ public abstract class BuildIntegrationTests : RepoTestBase, IClassFixture<MSBuil
         propertyGroup.AddProperty("TargetExt", ".notdll");
 
         this.WriteVersionFile();
-        var result = await this.BuildAsync(Targets.GenerateAssemblyVersionInfo, logVerbosity: LoggerVerbosity.Minimal);
+        var result = await this.BuildAsync(Targets.GenerateAssemblyNBGVVersionInfo, logVerbosity: LoggerVerbosity.Minimal);
         string versionCsFilePath = Path.Combine(this.projectDirectory, result.BuildResult.ProjectStateAfterBuild.GetPropertyValue("VersionSourceFile"));
         Assert.False(File.Exists(versionCsFilePath));
         Assert.Empty(result.LoggedEvents.OfType<BuildErrorEventArgs>());
@@ -1263,8 +1263,13 @@ public abstract class BuildIntegrationTests : RepoTestBase, IClassFixture<MSBuil
         internal const string Build = "Build";
         internal const string GetBuildVersion = "GetBuildVersion";
         internal const string GetNuGetPackageVersion = "GetNuGetPackageVersion";
-        internal const string GenerateAssemblyVersionInfo = "GenerateAssemblyVersionInfo";
+        internal const string GenerateAssemblyNBGVVersionInfo = "GenerateAssemblyNBGVVersionInfo";
         internal const string GenerateNativeVersionInfo = "GenerateNativeVersionInfo";
+    }
+
+    private static class Properties
+    {
+        internal const string GenerateAssemblyVersionInfo = "GenerateAssemblyVersionInfo";
     }
 
     private class BuildResults

--- a/src/Nerdbank.GitVersioning.Tasks/build/Nerdbank.GitVersioning.targets
+++ b/src/Nerdbank.GitVersioning.Tasks/build/Nerdbank.GitVersioning.targets
@@ -42,7 +42,7 @@
 
       <!-- Workaround the property stomping that msbuild does (see https://github.com/microsoft/msbuild/pull/4922) with manual imports. -->
       <PrepareForBuildDependsOn>
-        GenerateNativeVersionInfo;
+        GenerateNativeNBGVVersionInfo;
         $(PrepareForBuildDependsOn);
       </PrepareForBuildDependsOn>
 
@@ -156,7 +156,7 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="GenerateNativeVersionInfo" DependsOnTargets="GetBuildVersion" Condition=" '$(Language)'=='C++' and '$(GenerateAssemblyVersionInfo)' != 'false' ">
+  <Target Name="GenerateNativeNBGVVersionInfo" DependsOnTargets="GetBuildVersion" Condition=" '$(Language)'=='C++' and '$(GenerateAssemblyVersionInfo)' != 'false' ">
     <PropertyGroup>
       <VersionSourceFile>$([MSBuild]::NormalizePath('$(IntermediateOutputPath)', '$(AssemblyName).Version.rc'))</VersionSourceFile>
       <NewVersionSourceFile>$(VersionSourceFile).new</NewVersionSourceFile>

--- a/src/Nerdbank.GitVersioning.Tasks/build/Nerdbank.GitVersioning.targets
+++ b/src/Nerdbank.GitVersioning.Tasks/build/Nerdbank.GitVersioning.targets
@@ -47,12 +47,12 @@
       </PrepareForBuildDependsOn>
 
       <PrepareResourcesDependsOn>
-        GenerateAssemblyVersionInfo;
+        GenerateAssemblyNBGVVersionInfo;
         $(PrepareResourcesDependsOn)
       </PrepareResourcesDependsOn>
 
       <CoreCompileDependsOn>
-        GenerateAssemblyVersionInfo;
+        GenerateAssemblyNBGVVersionInfo;
         $(CoreCompileDependsOn)
       </CoreCompileDependsOn>
 
@@ -112,7 +112,7 @@
 
   <Target Name="GetNuGetPackageVersion" DependsOnTargets="GetBuildVersion" Returns="$(NuGetPackageVersion)" />
 
-  <Target Name="GenerateAssemblyVersionInfo" DependsOnTargets="GetBuildVersion" Condition=" '$(GenerateAssemblyVersionInfo)' != 'false' ">
+  <Target Name="GenerateAssemblyNBGVVersionInfo" DependsOnTargets="GetBuildVersion" Condition=" '$(GenerateAssemblyVersionInfo)' != 'false' ">
     <PropertyGroup>
       <VersionSourceFile>$([MSBuild]::NormalizePath('$(IntermediateOutputPath)', '$(AssemblyName).Version$(DefaultLanguageSourceExtension)'))</VersionSourceFile>
       <NewVersionSourceFile>$(VersionSourceFile).new</NewVersionSourceFile>
@@ -215,7 +215,7 @@
   <Target Name="AddVersionFile"
           Condition="'@(RazorGenerate->Count())' != '0'"
           BeforeTargets="PrepareForRazorCompile"
-          DependsOnTargets="GenerateAssemblyVersionInfo">
+          DependsOnTargets="GenerateAssemblyNBGVVersionInfo">
     <ItemGroup>
       <RazorCompile Include="$(VersionSourceFile)" />
     </ItemGroup>


### PR DESCRIPTION
Fixes #698