### PR TITLE
Update schema to encourage 3-4 component assembly versions as well

### DIFF
--- a/src/NerdBank.GitVersioning.Tests/VersionFileTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/VersionFileTests.cs
@@ -92,6 +92,8 @@ public abstract class VersionFileTests : RepoTestBase
     [Theory]
     [InlineData("2.3", null, null, 0, null, @"{""version"":""2.3""}")]
     [InlineData("2.3", "2.2", VersionOptions.VersionPrecision.Minor, 0, null, @"{""version"":""2.3"",""assemblyVersion"":""2.2""}")]
+    [InlineData("2.3", "1.2.3", VersionOptions.VersionPrecision.Minor, 0, null, @"{""version"":""2.3"",""assemblyVersion"":{""version"":""1.2.3""}}")]
+    [InlineData("2.3", "1.2.3.4", VersionOptions.VersionPrecision.Minor, 0, null, @"{""version"":""2.3"",""assemblyVersion"":{""version"":""1.2.3.4""}}")]
     [InlineData("2.3", "2.2", VersionOptions.VersionPrecision.Minor, -1, new[] { "refs/heads/master" }, @"{""version"":""2.3"",""assemblyVersion"":""2.2"",""versionHeightOffset"":-1,""publicReleaseRefSpec"":[""refs/heads/master""]}")]
     [InlineData("2.3", "2.2", VersionOptions.VersionPrecision.Minor, -1, new[] { "refs/heads/master" }, @"{""version"":""2.3"",""assemblyVersion"":""2.2"",""buildNumberOffset"":-1,""publicReleaseRefSpec"":[""refs/heads/master""]}")]
     [InlineData("2.3", "2.2", VersionOptions.VersionPrecision.Minor, 0, null, @"{""version"":""2.3"",""assemblyVersion"":{""version"":""2.2""}}")]

--- a/src/NerdBank.GitVersioning/VersionOptions.cs
+++ b/src/NerdBank.GitVersioning/VersionOptions.cs
@@ -741,7 +741,7 @@ namespace Nerdbank.GitVersioning
             }
 
             /// <summary>
-            /// Gets or sets the major.minor components of the assembly version.
+            /// Gets or sets the components of the assembly version (2-4 components).
             /// </summary>
             [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
             public Version? Version

--- a/src/NerdBank.GitVersioning/version.schema.json
+++ b/src/NerdBank.GitVersioning/version.schema.json
@@ -39,13 +39,13 @@
           "default": false
         },
         "assemblyVersion": {
-          "description": "The x.y version to use particularly for the AssemblyVersionAttribute instead of the default. This is useful when maintaining assembly binding compatibility on the desktop .NET Framework is important even though AssemblyFileVersion may change.",
+          "description": "The a.b[.c[.d]] version to use particularly for the AssemblyVersionAttribute instead of the default. This is useful when maintaining assembly binding compatibility on the desktop .NET Framework is important even though AssemblyFileVersion may change.",
           "oneOf": [
-            { "$ref": "#/definitions/majorMinorVersion" },
+            { "$ref": "#/definitions/twoToFourComponentVersion" },
             {
               "type": "object",
               "properties": {
-                "version": { "$ref": "#/definitions/majorMinorVersion" },
+                "version": { "$ref": "#/definitions/twoToFourComponentVersion" },
                 "precision": {
                   "type": "string",
                   "description": "Identifies the last component to be explicitly set in the version.",
@@ -193,10 +193,10 @@
         }
       }
     },
-    "majorMinorVersion": {
+    "twoToFourComponentVersion": {
       "type": "string",
-      "description": "A major.minor version",
-      "pattern": "^\\d+\\.\\d+$"
+      "description": "A major.minor[.build[.revision]] version (2-4 version components).",
+      "pattern": "^\\d+\\.\\d+(?:\\.\\d+(?:\\.\\d+)?)?$"
     }
   }
 }


### PR DESCRIPTION
The product already supported it, but the schema and tests did not reflect this.

Closes #703