### PR TITLE
Honor AssemblyVersion as explicitly set in version.json

### DIFF
--- a/src/NerdBank.GitVersioning.Tests/BuildIntegrationTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/BuildIntegrationTests.cs
@@ -1009,13 +1009,19 @@ public abstract class BuildIntegrationTests : RepoTestBase, IClassFixture<MSBuil
     {
         // Function should be very similar to VersionOracle.GetAssemblyVersion()
         var assemblyVersion = (versionOptions?.AssemblyVersion?.Version ?? versionOptions.Version.Version).EnsureNonNegativeComponents();
-        var precision = versionOptions?.AssemblyVersion?.Precision ?? VersionOptions.DefaultVersionPrecision;
 
-        assemblyVersion = new System.Version(
-            assemblyVersion.Major,
-            precision >= VersionOptions.VersionPrecision.Minor ? assemblyVersion.Minor : 0,
-            precision >= VersionOptions.VersionPrecision.Build ? version.Build : 0,
-            precision >= VersionOptions.VersionPrecision.Revision ? version.Revision : 0);
+        if (versionOptions?.AssemblyVersion?.Version is null)
+        {
+            VersionOptions.VersionPrecision precision = versionOptions?.AssemblyVersion?.Precision ?? VersionOptions.DefaultVersionPrecision;
+            assemblyVersion = version;
+
+            assemblyVersion = new Version(
+                assemblyVersion.Major,
+                precision >= VersionOptions.VersionPrecision.Minor ? assemblyVersion.Minor : 0,
+                precision >= VersionOptions.VersionPrecision.Build ? assemblyVersion.Build : 0,
+                precision >= VersionOptions.VersionPrecision.Revision ? assemblyVersion.Revision : 0);
+        }
+
         return assemblyVersion;
     }
 

--- a/src/NerdBank.GitVersioning.Tests/VersionOracleTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/VersionOracleTests.cs
@@ -259,6 +259,32 @@ public abstract class VersionOracleTests : RepoTestBase
         Assert.Matches(@"^2.3.1-g[a-f0-9]{7}$", oracle.ChocolateyPackageVersion);
     }
 
+    [Theory]
+    [InlineData("1.2.0.0", null, null)]
+    [InlineData("1.0.0.0", null, VersionOptions.VersionPrecision.Major)]
+    [InlineData("1.2.0.0", null, VersionOptions.VersionPrecision.Minor)]
+    [InlineData("1.2.1.0", null, VersionOptions.VersionPrecision.Build)]
+    [InlineData("2.3.4.0", "2.3.4", null)]
+    [InlineData("2.3.4.0", "2.3.4", VersionOptions.VersionPrecision.Minor)]
+    [InlineData("2.3.4.0", "2.3.4", VersionOptions.VersionPrecision.Build)]
+    [InlineData("2.3.4.0", "2.3.4.0", VersionOptions.VersionPrecision.Revision)]
+    public void CustomAssemblyVersion(string expectedAssemblyVersion, string prescribedAssemblyVersion, VersionOptions.VersionPrecision? precision)
+    {
+        this.InitializeSourceControl(withInitialCommit: false);
+        this.WriteVersionFile(new VersionOptions
+        {
+            Version = new SemanticVersion("1.2"),
+            AssemblyVersion = new VersionOptions.AssemblyVersionOptions
+            {
+                Version = prescribedAssemblyVersion is object ? new Version(prescribedAssemblyVersion) : null,
+                Precision = precision,
+            },
+        });
+
+        VersionOracle oracle = this.GetVersionOracle();
+        Assert.Equal(expectedAssemblyVersion, oracle.AssemblyVersion.ToString());
+    }
+
     [Fact]
     public void DefaultNuGetPackageVersionIsSemVer1PublicRelease()
     {

--- a/src/NerdBank.GitVersioning/VersionOracle.cs
+++ b/src/NerdBank.GitVersioning/VersionOracle.cs
@@ -444,14 +444,25 @@ namespace Nerdbank.GitVersioning
             // If there is no repo, "version" could have uninitialized components (-1).
             version = version.EnsureNonNegativeComponents();
 
-            var assemblyVersion = versionOptions?.AssemblyVersionOrDefault.Version ?? new System.Version(version.Major, version.Minor);
-            var precision = versionOptions?.AssemblyVersionOrDefault.PrecisionOrDefault;
+            Version assemblyVersion;
 
-            assemblyVersion = new System.Version(
-                assemblyVersion.Major,
-                precision >= VersionOptions.VersionPrecision.Minor ? assemblyVersion.Minor : 0,
-                precision >= VersionOptions.VersionPrecision.Build ? version.Build : 0,
-                precision >= VersionOptions.VersionPrecision.Revision ? version.Revision : 0);
+            if (versionOptions?.AssemblyVersion?.Version is not null)
+            {
+                // When specified explicitly, use the assembly version as the user defines it.
+                assemblyVersion = versionOptions.AssemblyVersion.Version;
+            }
+            else
+            {
+                // Otherwise consider precision to base the assembly version off of the main computed version.
+                VersionOptions.VersionPrecision precision = versionOptions?.AssemblyVersion?.Precision ?? VersionOptions.DefaultVersionPrecision;
+
+                assemblyVersion = new Version(
+                    version.Major,
+                    precision >= VersionOptions.VersionPrecision.Minor ? version.Minor : 0,
+                    precision >= VersionOptions.VersionPrecision.Build ? version.Build : 0,
+                    precision >= VersionOptions.VersionPrecision.Revision ? version.Revision : 0);
+            }
+
             return assemblyVersion.EnsureNonNegativeComponents(4);
         }
 

--- a/src/NerdBank.GitVersioning/version.schema.json
+++ b/src/NerdBank.GitVersioning/version.schema.json
@@ -44,8 +44,15 @@
             { "$ref": "#/definitions/twoToFourComponentVersion" },
             {
               "type": "object",
+              "additionalProperties": false,
               "properties": {
-                "version": { "$ref": "#/definitions/twoToFourComponentVersion" },
+                "version": { "$ref": "#/definitions/twoToFourComponentVersion" }
+              }
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
                 "precision": {
                   "type": "string",
                   "description": "Identifies the last component to be explicitly set in the version.",


### PR DESCRIPTION
Allow AssemblyVersion to be set explicitly without being altered by the rest of the computed build version

**Breaking change**: The `assemblyVersion.precision` property in the `version.json` file is now ignored if `assemblyVersion.version` is set to a non-null value. When set, `assemblyVersion.version` is taken literally.
Specifying `assemblyVersion.precision` alone will still set the assembly version based on the ordinary computed `version` as it did before.

The schema has been updated to reflect that specifying `assemblyVersion.version` *and* `assemblyVersion.precision` is an error.

Fixes #703