### PR TITLE
Add 'precision' setting for the NuGet package version

### DIFF
--- a/doc/versionJson.md
+++ b/doc/versionJson.md
@@ -39,6 +39,7 @@ The content of the version.json file is a JSON serialized object with these prop
   "gitCommitIdShortAutoMinimum": 0, // optional. Set to use the short commit ID abbreviation provided by the git repository.
   "nugetPackageVersion": {
      "semVer": 1 // optional. Set to either 1 or 2 to control how the NuGet package version string is generated. Default is 1.
+     "precision": "build" // optional. Use when you want to a more or less precise package version than the default major.minor.build.
   },
   "pathFilters": [
     // optional list of paths to consider when calculating version height.

--- a/src/NerdBank.GitVersioning.Tests/VersionFileTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/VersionFileTests.cs
@@ -608,6 +608,38 @@ public abstract class VersionFileTests : RepoTestBase
         Assert.True(Path.IsPathRooted(actualDirectory));
     }
 
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(2)]
+    public void GetVersion_ReadNuGetPackageVersionSettings_SemVer(int semVer)
+    {
+        var json = $@"{{ ""version"" : ""1.0"", ""nugetPackageVersion"" : {{ ""semVer"" : {semVer}  }} }}";
+        var path = Path.Combine(this.RepoPath, "version.json");
+        File.WriteAllText(path, json);
+
+        var versionOptions = this.Context.VersionFile.GetVersion();
+
+        Assert.NotNull(versionOptions.NuGetPackageVersion);
+        Assert.NotNull(versionOptions.NuGetPackageVersion.SemVer);
+        Assert.Equal(semVer, versionOptions.NuGetPackageVersion.SemVer);
+    }
+
+    [Theory]
+    [CombinatorialData]
+    public void GetVersion_ReadNuGetPackageVersionSettings_Precision(VersionOptions.VersionPrecision precision)
+    {
+        var json = $@"{{ ""version"" : ""1.0"", ""nugetPackageVersion"" : {{ ""precision"" : ""{precision}""  }} }}";
+        var path = Path.Combine(this.RepoPath, "version.json");
+        File.WriteAllText(path, json);
+
+        var versionOptions = this.Context.VersionFile.GetVersion();
+
+        Assert.NotNull(versionOptions.NuGetPackageVersion);
+        Assert.NotNull(versionOptions.NuGetPackageVersion.Precision);
+        Assert.Equal(precision, versionOptions.NuGetPackageVersion.Precision);
+    }
+
     private void AssertPathHasVersion(string committish, string absolutePath, VersionOptions expected)
     {
         var actual = this.GetVersionOptions(absolutePath, committish);

--- a/src/NerdBank.GitVersioning.Tests/VersionOptionsTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/VersionOptionsTests.cs
@@ -178,6 +178,7 @@ public class VersionOptionsTests
         Assert.Throws<InvalidOperationException>(() => options.CloudBuildOrDefault.BuildNumberOrDefault.IncludeCommitIdOrDefault.Where = VersionOptions.CloudBuildNumberCommitWhere.BuildMetadata);
         Assert.Throws<InvalidOperationException>(() => options.CloudBuildOrDefault.SetVersionVariables = true);
         Assert.Throws<InvalidOperationException>(() => options.NuGetPackageVersionOrDefault.SemVer = 2);
+        Assert.Throws<InvalidOperationException>(() => options.NuGetPackageVersionOrDefault.Precision = VersionOptions.VersionPrecision.Revision);
         Assert.Throws<InvalidOperationException>(() => options.ReleaseOrDefault.BranchName = "BranchName");
         Assert.Throws<InvalidOperationException>(() => options.ReleaseOrDefault.VersionIncrement = VersionOptions.ReleaseVersionIncrement.Major);
         Assert.Throws<InvalidOperationException>(() => options.ReleaseOrDefault.FirstUnstableTag = "-tag");
@@ -225,5 +226,31 @@ public class VersionOptionsTests
         Assert.NotEqual(ro1, ro5);
         Assert.NotEqual(ro3, ro5);
         Assert.NotEqual(ro5, ro6);
+    }
+
+    [Fact]
+    public void NuGetPackageVersionOptions_Equality()
+    {
+        var npvo1a = new VersionOptions.NuGetPackageVersionOptions { };
+        var npvo1b = new VersionOptions.NuGetPackageVersionOptions { };
+        Assert.Equal(npvo1a, npvo1b);
+
+        var npvo2a = new VersionOptions.NuGetPackageVersionOptions
+        {
+            SemVer = 2
+        };
+        Assert.NotEqual(npvo2a, npvo1a);
+
+        var npvo3a = new VersionOptions.NuGetPackageVersionOptions
+        {
+            Precision = VersionOptions.VersionPrecision.Revision
+        };
+        Assert.NotEqual(npvo3a, npvo1a);
+
+        var npvo4a = new VersionOptions.NuGetPackageVersionOptions
+        {
+            Precision = VersionOptions.VersionPrecision.Build
+        };
+        Assert.Equal(npvo4a, npvo1a); // Equal because we haven't changed defaults.
     }
 }

--- a/src/NerdBank.GitVersioning.Tests/VersionOracleTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/VersionOracleTests.cs
@@ -372,6 +372,92 @@ public abstract class VersionOracleTests : RepoTestBase
         Assert.Equal($"7.8.9-foo.25", oracle.NuGetPackageVersion);
     }
 
+    [Theory]
+    //
+    // SemVer 1
+    //
+    // 2 version fields configured in version.json
+    [InlineData(1, "1.2", VersionOptions.VersionPrecision.Major, "1.0.0")]
+    [InlineData(1, "1.2", VersionOptions.VersionPrecision.Minor, "1.2.0")]
+    [InlineData(1, "1.2", VersionOptions.VersionPrecision.Build, "1.2.1")]
+    [InlineData(1, "1.2", VersionOptions.VersionPrecision.Revision, "1.2.1.<commit>")]
+    // 2 version fields configured in version.json
+    [InlineData(1, "1.2.3", VersionOptions.VersionPrecision.Major, "1.0.0")]
+    [InlineData(1, "1.2.3", VersionOptions.VersionPrecision.Minor, "1.2.0")]
+    [InlineData(1, "1.2.3", VersionOptions.VersionPrecision.Build, "1.2.3")]
+    [InlineData(1, "1.2.3", VersionOptions.VersionPrecision.Revision, "1.2.3.1")]
+    // 4 version fields configured in version.json
+    [InlineData(1, "1.2.3.4", VersionOptions.VersionPrecision.Major, "1.0.0")]
+    [InlineData(1, "1.2.3.4", VersionOptions.VersionPrecision.Minor, "1.2.0")]
+    [InlineData(1, "1.2.3.4", VersionOptions.VersionPrecision.Build, "1.2.3")]
+    [InlineData(1, "1.2.3.4", VersionOptions.VersionPrecision.Revision, "1.2.3.4")]
+    // 2 version fields with git height in prerelease tag configured in version.json
+    [InlineData(1, "1.2-alpha.{height}", VersionOptions.VersionPrecision.Major, "1.0.0-alpha-0001")]
+    [InlineData(1, "1.2-alpha.{height}", VersionOptions.VersionPrecision.Minor, "1.2.0-alpha-0001")]
+    [InlineData(1, "1.2-alpha.{height}", VersionOptions.VersionPrecision.Build, "1.2.0-alpha-0001")]
+    [InlineData(1, "1.2-alpha.{height}", VersionOptions.VersionPrecision.Revision, "1.2.0.0-alpha-0001")]
+    // 3 version fields with git height in prerelease tag configured in version.json
+    [InlineData(1, "1.2.3-alpha.{height}", VersionOptions.VersionPrecision.Major, "1.0.0-alpha-0001")]
+    [InlineData(1, "1.2.3-alpha.{height}", VersionOptions.VersionPrecision.Minor, "1.2.0-alpha-0001")]
+    [InlineData(1, "1.2.3-alpha.{height}", VersionOptions.VersionPrecision.Build, "1.2.3-alpha-0001")]
+    [InlineData(1, "1.2.3-alpha.{height}", VersionOptions.VersionPrecision.Revision, "1.2.3.0-alpha-0001")]
+    // 4 version fields with git height in prerelease tag configured in version.json
+    [InlineData(1, "1.2.3.4-alpha.{height}", VersionOptions.VersionPrecision.Major, "1.0.0-alpha-0001")]
+    [InlineData(1, "1.2.3.4-alpha.{height}", VersionOptions.VersionPrecision.Minor, "1.2.0-alpha-0001")]
+    [InlineData(1, "1.2.3.4-alpha.{height}", VersionOptions.VersionPrecision.Build, "1.2.3-alpha-0001")]
+    [InlineData(1, "1.2.3.4-alpha.{height}", VersionOptions.VersionPrecision.Revision, "1.2.3.4-alpha-0001")]
+    //
+    // SemVer 2
+    //
+    // 2 version fields configured in version.json
+    [InlineData(2, "1.2", VersionOptions.VersionPrecision.Major, "1.0.0")]
+    [InlineData(2, "1.2", VersionOptions.VersionPrecision.Minor, "1.2.0")]
+    [InlineData(2, "1.2", VersionOptions.VersionPrecision.Build, "1.2.1")]
+    [InlineData(2, "1.2", VersionOptions.VersionPrecision.Revision, "1.2.1.<commit>")]
+    // 3 version fields configured in version.json
+    [InlineData(2, "1.2.3", VersionOptions.VersionPrecision.Major, "1.0.0")]
+    [InlineData(2, "1.2.3", VersionOptions.VersionPrecision.Minor, "1.2.0")]
+    [InlineData(2, "1.2.3", VersionOptions.VersionPrecision.Build, "1.2.3")]
+    [InlineData(2, "1.2.3", VersionOptions.VersionPrecision.Revision, "1.2.3.1")]
+    // 4 version fields configured in version.json
+    [InlineData(2, "1.2.3.4", VersionOptions.VersionPrecision.Major, "1.0.0")]
+    [InlineData(2, "1.2.3.4", VersionOptions.VersionPrecision.Minor, "1.2.0")]
+    [InlineData(2, "1.2.3.4", VersionOptions.VersionPrecision.Build, "1.2.3")]
+    [InlineData(2, "1.2.3.4", VersionOptions.VersionPrecision.Revision, "1.2.3.4")]
+    // 2 version fields with git height in prerelease tag configured in version.json
+    [InlineData(2, "1.2-alpha.{height}", VersionOptions.VersionPrecision.Major, "1.0.0-alpha.1")]
+    [InlineData(2, "1.2-alpha.{height}", VersionOptions.VersionPrecision.Minor, "1.2.0-alpha.1")]
+    [InlineData(2, "1.2-alpha.{height}", VersionOptions.VersionPrecision.Build, "1.2.0-alpha.1")]
+    [InlineData(2, "1.2-alpha.{height}", VersionOptions.VersionPrecision.Revision, "1.2.0.0-alpha.1")]
+    // 3 version fields with git height in prerelease tag configured in version.json
+    [InlineData(2, "1.2.3-alpha.{height}", VersionOptions.VersionPrecision.Major, "1.0.0-alpha.1")]
+    [InlineData(2, "1.2.3-alpha.{height}", VersionOptions.VersionPrecision.Minor, "1.2.0-alpha.1")]
+    [InlineData(2, "1.2.3-alpha.{height}", VersionOptions.VersionPrecision.Build, "1.2.3-alpha.1")]
+    [InlineData(2, "1.2.3-alpha.{height}", VersionOptions.VersionPrecision.Revision, "1.2.3.0-alpha.1")]
+    // 4 version fields with git height in prerelease tag configured in version.json
+    [InlineData(2, "1.2.3.4-alpha.{height}", VersionOptions.VersionPrecision.Major, "1.0.0-alpha.1")]
+    [InlineData(2, "1.2.3.4-alpha.{height}", VersionOptions.VersionPrecision.Minor, "1.2.0-alpha.1")]
+    [InlineData(2, "1.2.3.4-alpha.{height}", VersionOptions.VersionPrecision.Build, "1.2.3-alpha.1")]
+    [InlineData(2, "1.2.3.4-alpha.{height}", VersionOptions.VersionPrecision.Revision, "1.2.3.4-alpha.1")]
+    public void CanSetPrecisionForNuGetPackageVersion(int semVer, string version, VersionOptions.VersionPrecision precision, string expectedPackageVersion)
+    {
+        VersionOptions workingCopyVersion = new VersionOptions
+        {
+            Version = SemanticVersion.Parse(version),
+            NuGetPackageVersion = new VersionOptions.NuGetPackageVersionOptions
+            {
+                SemVer = semVer,
+                Precision = precision
+            }
+        };
+        this.WriteVersionFile(workingCopyVersion);
+        this.InitializeSourceControl();
+        var oracle = new VersionOracle(this.Context);
+        oracle.PublicRelease = true;
+        expectedPackageVersion = expectedPackageVersion.Replace("<commit>", oracle.Version.Revision.ToString());
+        Assert.Equal(expectedPackageVersion, oracle.NuGetPackageVersion);
+    }
+
     [Fact]
     public void CanSetSemVer2ForNuGetPackageVersionNonPublicRelease()
     {

--- a/src/NerdBank.GitVersioning/VersionOptions.cs
+++ b/src/NerdBank.GitVersioning/VersionOptions.cs
@@ -584,6 +584,7 @@ namespace Nerdbank.GitVersioning
             {
                 isFrozen = true,
                 semVer = 1.0f,
+                precision = VersionPrecision.Build
             };
 
             [DebuggerBrowsable(DebuggerBrowsableState.Never)]
@@ -591,6 +592,9 @@ namespace Nerdbank.GitVersioning
 
             [DebuggerBrowsable(DebuggerBrowsableState.Never)]
             private float? semVer;
+
+            [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+            private VersionPrecision? precision;
 
             /// <summary>
             /// Initializes a new instance of the <see cref="NuGetPackageVersionOptions" /> class.
@@ -622,6 +626,22 @@ namespace Nerdbank.GitVersioning
             /// </summary>
             [JsonIgnore]
             public float? SemVerOrDefault => this.SemVer ?? DefaultInstance.SemVer;
+
+            /// <summary>
+            /// Gets or sets number of version components to include when generating the package version.
+            /// </summary>
+            [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+            public VersionPrecision? Precision
+            {
+                get => this.precision;
+                set => this.SetIfNotReadOnly(ref this.precision, value);
+            }
+
+            /// <summary>
+            /// Gets the number of version components to include when generating the package version.
+            /// </summary>
+            [JsonIgnore]
+            public VersionPrecision PrecisionOrDefault => this.Precision ?? DefaultInstance.Precision!.Value;
 
             /// <summary>
             /// Gets a value indicating whether this instance rejects all attempts to mutate it.
@@ -679,13 +699,22 @@ namespace Nerdbank.GitVersioning
                         return false;
                     }
 
-                    return x.SemVerOrDefault == y.SemVerOrDefault;
+                    return x.SemVerOrDefault == y.SemVerOrDefault &&
+                           x.PrecisionOrDefault == y.PrecisionOrDefault;
                 }
 
                 /// <inheritdoc />
                 public int GetHashCode(NuGetPackageVersionOptions? obj)
                 {
-                    return obj?.SemVerOrDefault.GetHashCode() ?? 0;
+                    if (obj is null)
+                        return 0;
+
+                    unchecked
+                    {
+                        var hash = obj.SemVerOrDefault.GetHashCode() * 397;
+                        hash ^= obj.PrecisionOrDefault.GetHashCode();
+                        return hash;
+                    }
                 }
             }
         }

--- a/src/NerdBank.GitVersioning/VersionOptions.cs
+++ b/src/NerdBank.GitVersioning/VersionOptions.cs
@@ -584,7 +584,7 @@ namespace Nerdbank.GitVersioning
             {
                 isFrozen = true,
                 semVer = 1.0f,
-                precision = VersionPrecision.Build
+                precision = DefaultPrecision,
             };
 
             [DebuggerBrowsable(DebuggerBrowsableState.Never)]
@@ -595,6 +595,11 @@ namespace Nerdbank.GitVersioning
 
             [DebuggerBrowsable(DebuggerBrowsableState.Never)]
             private VersionPrecision? precision;
+
+            /// <summary>
+            /// Default value for <see cref="Precision"/>.
+            /// </summary>
+            public const VersionPrecision DefaultPrecision = VersionPrecision.Build;
 
             /// <summary>
             /// Initializes a new instance of the <see cref="NuGetPackageVersionOptions" /> class.

--- a/src/NerdBank.GitVersioning/VersionOracle.cs
+++ b/src/NerdBank.GitVersioning/VersionOracle.cs
@@ -353,7 +353,7 @@ namespace Nerdbank.GitVersioning
         /// <summary>
         /// Gets the version to use for NuGet packages.
         /// </summary>
-        public string NuGetPackageVersion => this.VersionOptions?.NuGetPackageVersionOrDefault.SemVerOrDefault == 1 ? this.NuGetSemVer1 : this.SemVer2;
+        public string NuGetPackageVersion => this.VersionOptions?.NuGetPackageVersionOrDefault.SemVerOrDefault == 1 ? this.NuGetSemVer1 : this.NuGetSemVer2;
 
         /// <summary>
         /// Gets the version to use for Chocolatey packages.
@@ -414,8 +414,39 @@ namespace Nerdbank.GitVersioning
         /// Gets a SemVer 1.0 compliant string that represents this version, including the -gCOMMITID suffix
         /// when <see cref="PublicRelease"/> is <c>false</c>.
         /// </summary>
-        private string NuGetSemVer1 =>
-            $"{this.Version.ToStringSafe(3)}{this.PrereleaseVersionSemVer1}{this.NuGetSemVer1BuildMetadata}";
+        private string NuGetSemVer1
+        {
+            get
+            {
+                var precision = this.VersionOptions?.NuGetPackageVersionOrDefault.PrecisionOrDefault ?? VersionOptions.NuGetPackageVersionOptions.DefaultPrecision;
+                var version = this.Version.EnsureNonNegativeComponents();
+                version = ApplyVersionPrecision(version, precision);
+
+                // If precision is set to include the 4th version component, return all 4 version fields, otherwise return 3 fields.
+                var fieldCount = precision >= VersionOptions.VersionPrecision.Revision ? 4 : 3;
+
+                return $"{version.ToStringSafe(fieldCount)}{this.PrereleaseVersionSemVer1}{this.NuGetSemVer1BuildMetadata}";
+            }
+        }
+
+        /// <summary>
+        /// Gets a SemVer 2.0 compliant string that represents this version, including the -gCOMMITID suffix
+        /// when <see cref="PublicRelease"/> is <c>false</c>.
+        /// </summary>
+        private string NuGetSemVer2
+        {
+            get
+            {
+                var precision = this.VersionOptions?.NuGetPackageVersionOrDefault.PrecisionOrDefault ?? VersionOptions.NuGetPackageVersionOptions.DefaultPrecision;
+                var version = this.Version.EnsureNonNegativeComponents();
+                version = ApplyVersionPrecision(version, precision);
+
+                // If precision is set to include the 4th version component, return all 4 version fields, otherwise return 3 fields.
+                var fieldCount = precision >= VersionOptions.VersionPrecision.Revision ? 4 : 3;
+
+                return $"{version.ToStringSafe(fieldCount)}{this.PrereleaseVersion}{this.SemVer2BuildMetadata}";
+            }
+        }
 
         /// <summary>
         /// Gets the build metadata that is appropriate for SemVer2 use.
@@ -461,15 +492,19 @@ namespace Nerdbank.GitVersioning
             {
                 // Otherwise consider precision to base the assembly version off of the main computed version.
                 VersionOptions.VersionPrecision precision = versionOptions?.AssemblyVersion?.Precision ?? VersionOptions.DefaultVersionPrecision;
-
-                assemblyVersion = new Version(
-                    version.Major,
-                    precision >= VersionOptions.VersionPrecision.Minor ? version.Minor : 0,
-                    precision >= VersionOptions.VersionPrecision.Build ? version.Build : 0,
-                    precision >= VersionOptions.VersionPrecision.Revision ? version.Revision : 0);
+                assemblyVersion = ApplyVersionPrecision(version, precision);
             }
 
             return assemblyVersion.EnsureNonNegativeComponents(4);
+        }
+
+        private static Version ApplyVersionPrecision(Version version, VersionOptions.VersionPrecision precision)
+        {
+            return new Version(
+                version.Major,
+                precision >= VersionOptions.VersionPrecision.Minor ? version.Minor : 0,
+                precision >= VersionOptions.VersionPrecision.Build ? version.Build : 0,
+                precision >= VersionOptions.VersionPrecision.Revision ? version.Revision : 0);
         }
 
         /// <summary>

--- a/src/NerdBank.GitVersioning/version.schema.json
+++ b/src/NerdBank.GitVersioning/version.schema.json
@@ -108,6 +108,12 @@
               "default": 1,
               "minimum": 1,
               "maximum": 2
+            },
+            "precision": {
+              "type": "string",
+              "description": "Specifies the number of components to include in the NuGet package version.",
+              "enum": [ "major", "minor", "build", "revision" ],
+              "default": "build"
             }
           }
         },


### PR DESCRIPTION
Adds a `precision` setting to the `nugetPackageVersion` section in `version.json` which defaults to `build` (keeping the existing default behavior).

This allows configuring Nerdbank.GitVersioning to include a 4th version component by setting the precision to `revision`.

For completeness this also allows to include only the major and/or minor versions in the package version - though I do not know how useful this is.

Fixes #401 