### PR TITLE
Fix NullReferenceException thrown when PATH is empty/missing

### DIFF
--- a/src/Nerdbank.GitVersioning.Tasks/ContextAwareTask.cs
+++ b/src/Nerdbank.GitVersioning.Tasks/ContextAwareTask.cs
@@ -56,7 +56,7 @@
             // On .NET Framework (on Windows), we find native binaries by adding them to our PATH.
             if (this.UnmanagedDllDirectory is not null)
             {
-                string pathEnvVar = Environment.GetEnvironmentVariable("PATH");
+                string pathEnvVar = Environment.GetEnvironmentVariable("PATH") ?? string.Empty;
                 string[] searchPaths = pathEnvVar.Split(Path.PathSeparator);
                 if (!searchPaths.Contains(this.UnmanagedDllDirectory, StringComparer.OrdinalIgnoreCase))
                 {


### PR DESCRIPTION
Yup. That actually happens. VC++ targets set the PATH environment variable to an msbuild property that can be empty.