### PR TITLE
Move .NET 5 tests to .NET 6

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,7 +36,7 @@ stages:
       matrix:
         linux:
           imageName: 'ubuntu-20.04'
-          testModifier: -f net5.0
+          testModifier: -f net6.0
         windows:
           imageName: 'windows-2019'
           testModifier:
@@ -61,23 +61,15 @@ stages:
         version: 3.1.x
 
     - task: UseDotNet@2
-      displayName: Install .NET 5.0 SDK
-      inputs:
-        packageType: sdk # necessary for msbuild tests to run on .NET 5 runtime
-        version: 5.0.x
-
-    - task: UseDotNet@2
       displayName: Install .NET 6.0 SDK
       inputs:
         packageType: sdk
-        version: 6.0.100
-
+        version: 6.0.202
 
     - pwsh: |
         Invoke-WebRequest -Uri "https://dot.net/v1/dotnet-install.ps1" -OutFile dotnet-install.ps1
         & .\dotnet-install.ps1 -Architecture x86 -Channel 3.1 -InstallDir "C:\Program Files (x86)\dotnet\" -NoPath -Verbose -Runtime dotnet
-        & .\dotnet-install.ps1 -Architecture x86 -Channel 5.0 -InstallDir "C:\Program Files (x86)\dotnet\" -NoPath -Verbose
-        & .\dotnet-install.ps1 -Architecture x86 -Version 6.0.100 -InstallDir "C:\Program Files (x86)\dotnet\" -NoPath -Verbose
+        & .\dotnet-install.ps1 -Architecture x86 -Version 6.0.202 -InstallDir "C:\Program Files (x86)\dotnet\" -NoPath -Verbose
       displayName: Install 32-bit .NET SDK and runtimes
       condition: ne(variables['dotnet32'], '')
 
@@ -334,11 +326,6 @@ stages:
       inputs:
         packageType: runtime
         version: 3.1.x
-    - task: UseDotNet@2
-      displayName: Install .NET 5.0 runtime
-      inputs:
-        packageType: runtime
-        version: 5.0.x
     - task: UseDotNet@2
       displayName: Install .NET 6.0.100 SDK
       inputs:

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.100",
+    "version": "6.0.202",
     "rollForward": "patch",
     "allowPrerelease": false
   }

--- a/src/Cake.GitVersioning.Tests/Cake.GitVersioning.Tests.csproj
+++ b/src/Cake.GitVersioning.Tests/Cake.GitVersioning.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;net461</TargetFrameworks>
+    <TargetFrameworks>net6.0;net461</TargetFrameworks>
     <SignAssembly>false</SignAssembly>
     <IsTestProject>true</IsTestProject>
     <IsPackable>false</IsPackable>

--- a/src/NerdBank.GitVersioning.Tests/ManagedGit/GitPackTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/ManagedGit/GitPackTests.cs
@@ -5,6 +5,7 @@ using System.Security.Cryptography;
 using Nerdbank.GitVersioning;
 using Nerdbank.GitVersioning.ManagedGit;
 using Xunit;
+using ZLibStream = Nerdbank.GitVersioning.ManagedGit.ZLibStream;
 
 namespace ManagedGit
 {

--- a/src/NerdBank.GitVersioning.Tests/ManagedGit/ZLibStreamTest.cs
+++ b/src/NerdBank.GitVersioning.Tests/ManagedGit/ZLibStreamTest.cs
@@ -5,6 +5,7 @@ using System.Security.Cryptography;
 using System.Text;
 using Nerdbank.GitVersioning.ManagedGit;
 using Xunit;
+using ZLibStream = Nerdbank.GitVersioning.ManagedGit.ZLibStream;
 
 namespace ManagedGit
 {

--- a/src/NerdBank.GitVersioning.Tests/NerdBank.GitVersioning.Tests.csproj
+++ b/src/NerdBank.GitVersioning.Tests/NerdBank.GitVersioning.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;net461</TargetFrameworks>
+    <TargetFrameworks>net6.0;net461</TargetFrameworks>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <DebugType>full</DebugType>


### PR DESCRIPTION
.NET 5 is just a few days from falling out of official Microsoft support, so testing on it at this point makes no sense.
