### PR TITLE
DeltaStreamReader should interpret instruction with size 0 as 0x10000

### DIFF
--- a/src/NerdBank.GitVersioning/ManagedGit/DeltaStreamReader.cs
+++ b/src/NerdBank.GitVersioning/ManagedGit/DeltaStreamReader.cs
@@ -84,6 +84,12 @@ namespace Nerdbank.GitVersioning.ManagedGit
                 {
                     value.Size |= ((byte)stream.ReadByte() << 16);
                 }
+
+                // Size zero is automatically converted to 0x10000.
+                if (value.Size == 0)
+                {
+                    value.Size = 0x10000;
+                }
             }
 
             return value;


### PR DESCRIPTION
Fixes: https://github.com/dotnet/Nerdbank.GitVersioning/issues/817

https://git-scm.com/docs/pack-format/2.31.0#_instruction_to_copy_from_base_object:
"In its most compact form, this instruction only takes up one byte (0x80) with both offset and size omitted, which will have default values zero. There is another exception: size zero is automatically converted to 0x10000."