### PR TITLE
Drop support for .NET Framework 4.6.1

### DIFF
--- a/src/Nerdbank.GitVersioning.Tasks/AssemblyVersionInfo.cs
+++ b/src/Nerdbank.GitVersioning.Tasks/AssemblyVersionInfo.cs
@@ -37,7 +37,7 @@ namespace Nerdbank.GitVersioning.Tasks
 ------------------------------------------------------------------------------
 ";
 
-#if NET461
+#if NET462
         private static readonly CodeGeneratorOptions CodeGeneratorOptions = new CodeGeneratorOptions
         {
             BlankLinesBetweenMembers = false,
@@ -133,7 +133,7 @@ namespace Nerdbank.GitVersioning.Tasks
             return null;
         }
 
-#if NET461
+#if NET462
         /// <inheritdoc/>
         public override bool Execute()
         {
@@ -183,7 +183,7 @@ namespace Nerdbank.GitVersioning.Tasks
         }
 #endif
 
-#if !NET461
+#if !NET462
         /// <inheritdoc/>
         public override bool Execute()
         {
@@ -230,7 +230,7 @@ namespace Nerdbank.GitVersioning.Tasks
             }
         }
 
-#if NET461
+#if NET462
         private static CodeMemberField CreateField<T>(string name, T value)
         {
             return new CodeMemberField(typeof(T), name)

--- a/src/Nerdbank.GitVersioning.Tasks/NativeVersionInfo.cs
+++ b/src/Nerdbank.GitVersioning.Tasks/NativeVersionInfo.cs
@@ -177,7 +177,7 @@ END
             {
                 if (!int.TryParse(this.AssemblyLanguage, out lcid))
                 {
-#if NET461
+#if NET462
                     try
                     {
                         var cultureInfo = new CultureInfo(this.AssemblyLanguage);

--- a/src/Nerdbank.GitVersioning.Tasks/Nerdbank.GitVersioning.Tasks.csproj
+++ b/src/Nerdbank.GitVersioning.Tasks/Nerdbank.GitVersioning.Tasks.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net462;netcoreapp3.1</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 
     <NuSpecFile>Nerdbank.GitVersioning.nuspec</NuSpecFile>
@@ -27,7 +27,7 @@
   <Target Name="PackBuildOutputs" DependsOnTargets="SatelliteDllsProjectOutputGroup;DebugSymbolsProjectOutputGroup">
     <PropertyGroup>
       <BuildSubDir Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">MSBuildCore\</BuildSubDir>
-      <BuildSubDir Condition=" '$(TargetFramework)' == 'net461' ">MSBuildFull\</BuildSubDir>
+      <BuildSubDir Condition=" '$(TargetFramework)' == 'net462' ">MSBuildFull\</BuildSubDir>
     </PropertyGroup>
     <Error Text="Unrecognized TargetFramework" Condition=" '$(BuildSubDir)' == '' " />
     <ItemGroup>
@@ -71,7 +71,7 @@
   <ItemGroup>
     <ProjectReference Include="..\NerdBank.GitVersioning\Nerdbank.GitVersioning.csproj" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net461' ">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net462' ">
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="15.9.20" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">

--- a/src/Nerdbank.GitVersioning.Tasks/Nerdbank.GitVersioning.nuspec
+++ b/src/Nerdbank.GitVersioning.Tasks/Nerdbank.GitVersioning.nuspec
@@ -17,18 +17,18 @@ IMPORTANT: The 3.x release may produce a different version height than prior maj
     <repository type="git" url="https://github.com/dotnet/Nerdbank.GitVersioning.git" commit="$commit$" />
   </metadata>
   <files>
-    <file src="$BaseOutputPath$net461\LibGit2Sharp.dll" target="build\MSBuildFull\LibGit2Sharp.dll" />
-    <file src="$BaseOutputPath$net461\LibGit2Sharp.dll.config" target="build\MSBuildFull\LibGit2Sharp.dll.config" />
-    <file src="$BaseOutputPath$net461\Microsoft.DotNet.PlatformAbstractions.dll" target="build\MSBuildFull\Microsoft.DotNet.PlatformAbstractions.dll" />
-    <file src="$BaseOutputPath$net461\Nerdbank.GitVersioning.dll" target="build\MSBuildFull\Nerdbank.GitVersioning.dll" />
-    <file src="$BaseOutputPath$net461\Nerdbank.GitVersioning.Tasks.dll" target="build\MSBuildFull\Nerdbank.GitVersioning.Tasks.dll" />
-    <file src="$BaseOutputPath$net461\Newtonsoft.Json.dll" target="build\MSBuildFull\Newtonsoft.Json.dll" />
-    <file src="$BaseOutputPath$net461\System.Buffers.dll" target="build\MSBuildFull\System.Buffers.dll" />
-    <file src="$BaseOutputPath$net461\System.Memory.dll" target="build\MSBuildFull\System.Memory.dll" />
-    <file src="$BaseOutputPath$net461\System.Numerics.Vectors.dll" target="build\MSBuildFull\System.Numerics.Vectors.dll" />
-    <file src="$BaseOutputPath$net461\System.Runtime.CompilerServices.Unsafe.dll" target="build\MSBuildFull\System.Runtime.CompilerServices.Unsafe.dll" />
-    <file src="$BaseOutputPath$net461\System.Text.Json.dll" target="build\MSBuildFull\System.Text.Json.dll" />
-    <file src="$BaseOutputPath$net461\Validation.dll" target="build\MSBuildFull\Validation.dll" />
+    <file src="$BaseOutputPath$net462\LibGit2Sharp.dll" target="build\MSBuildFull\LibGit2Sharp.dll" />
+    <file src="$BaseOutputPath$net462\LibGit2Sharp.dll.config" target="build\MSBuildFull\LibGit2Sharp.dll.config" />
+    <file src="$BaseOutputPath$net462\Microsoft.DotNet.PlatformAbstractions.dll" target="build\MSBuildFull\Microsoft.DotNet.PlatformAbstractions.dll" />
+    <file src="$BaseOutputPath$net462\Nerdbank.GitVersioning.dll" target="build\MSBuildFull\Nerdbank.GitVersioning.dll" />
+    <file src="$BaseOutputPath$net462\Nerdbank.GitVersioning.Tasks.dll" target="build\MSBuildFull\Nerdbank.GitVersioning.Tasks.dll" />
+    <file src="$BaseOutputPath$net462\Newtonsoft.Json.dll" target="build\MSBuildFull\Newtonsoft.Json.dll" />
+    <file src="$BaseOutputPath$net462\System.Buffers.dll" target="build\MSBuildFull\System.Buffers.dll" />
+    <file src="$BaseOutputPath$net462\System.Memory.dll" target="build\MSBuildFull\System.Memory.dll" />
+    <file src="$BaseOutputPath$net462\System.Numerics.Vectors.dll" target="build\MSBuildFull\System.Numerics.Vectors.dll" />
+    <file src="$BaseOutputPath$net462\System.Runtime.CompilerServices.Unsafe.dll" target="build\MSBuildFull\System.Runtime.CompilerServices.Unsafe.dll" />
+    <file src="$BaseOutputPath$net462\System.Text.Json.dll" target="build\MSBuildFull\System.Text.Json.dll" />
+    <file src="$BaseOutputPath$net462\Validation.dll" target="build\MSBuildFull\Validation.dll" />
     <file src="$LibGit2SharpNativeBinaries$runtimes\**" target="build\runtimes\" />
 
     <!-- Additional copies to work around DllNotFoundException on Mono (https://github.com/dotnet/Nerdbank.GitVersioning/issues/222) -->

--- a/test/Nerdbank.GitVersioning.Benchmarks/Nerdbank.GitVersioning.Benchmarks.csproj
+++ b/test/Nerdbank.GitVersioning.Benchmarks/Nerdbank.GitVersioning.Benchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net461</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net462</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/test/Nerdbank.GitVersioning.Tests/Nerdbank.GitVersioning.Tests.csproj
+++ b/test/Nerdbank.GitVersioning.Tests/Nerdbank.GitVersioning.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net461</TargetFrameworks>
+    <TargetFrameworks>net6.0;net462</TargetFrameworks>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <DebugType>full</DebugType>


### PR DESCRIPTION
net461 support from Microsoft ended on April 26, 2022 per https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-framework
