### PR TITLE
fix: remove BOM from version.schema.json

### DIFF
--- a/src/NerdBank.GitVersioning/version.schema.json
+++ b/src/NerdBank.GitVersioning/version.schema.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "$schema": "http://json-schema.org/draft-04/schema",
   "title": "Nerdbank.GitVersioning version.json schema",
   "type": "object",


### PR DESCRIPTION
Fixes  #839

Visual Studio Code complains that the `version.schema.json` file contains a BOM, when referencing `https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json` as `$schema`.

This PR removes BOM from the `version.schema.json`. It shouldn't negatively impact any tooling.