### PR TITLE
Fix Cake.Tool install failure

### DIFF
--- a/azure-pipelines/xplattest-pipeline.yml
+++ b/azure-pipelines/xplattest-pipeline.yml
@@ -65,7 +65,7 @@ steps:
     cd caketest &&
     git init &&
     dotnet new tool-manifest &&
-    dotnet tool install Cake.Tool
+    dotnet tool install Cake.Tool --version 2.3.0
 
     echo "#addin nuget:?package=Cake.GitVersioning&version=${NBGV_NuGetPackageVersion}&prerelease=true"
 


### PR DESCRIPTION
This package recently shipped v3.0.0, which drops support for netcoreapp3.1, which is supported until 12/13/22.