### PR TITLE
Fix CloudBuildAllVars value formatting

### DIFF
--- a/src/NerdBank.GitVersioning/VersionOracle.cs
+++ b/src/NerdBank.GitVersioning/VersionOracle.cs
@@ -311,11 +311,9 @@ public class VersionOracle
                     continue;
                 }
 
-                const string isoDateTimeFormat = "yyyy'-'MM'-'dd'T'HH':'mm':'ss.FFFFFFFK";
-
                 string value = propertyValue switch
                 {
-                    DateTimeOffset dateTimeOffset => dateTimeOffset.ToString(isoDateTimeFormat, CultureInfo.InvariantCulture),
+                    DateTimeOffset dateTimeOffset => dateTimeOffset.ToString("o", CultureInfo.InvariantCulture),
                     _ => Convert.ToString(propertyValue, CultureInfo.InvariantCulture) ?? string.Empty,
                 };
 

--- a/src/NerdBank.GitVersioning/VersionOracle.cs
+++ b/src/NerdBank.GitVersioning/VersionOracle.cs
@@ -170,6 +170,7 @@ public class VersionOracle
     /// <summary>
     /// Gets the version options used to initialize this instance.
     /// </summary>
+    [Ignore]
     public VersionOptions? VersionOptions { get; }
 
     /// <summary>
@@ -296,17 +297,29 @@ public class VersionOracle
         {
             var variables = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
-            PropertyInfo[]? properties = this.GetType().GetTypeInfo().GetProperties(BindingFlags.Public | BindingFlags.DeclaredOnly | BindingFlags.Instance);
-            foreach (PropertyInfo? property in properties)
+            PropertyInfo[] properties = this.GetType().GetTypeInfo().GetProperties(BindingFlags.Public | BindingFlags.DeclaredOnly | BindingFlags.Instance);
+            foreach (PropertyInfo property in properties)
             {
-                if (property.GetCustomAttribute<IgnoreAttribute>() is null)
+                if (property.GetCustomAttribute<IgnoreAttribute>() is not null)
                 {
-                    object? value = property.GetValue(this);
-                    if (value is object)
-                    {
-                        variables.Add($"NBGV_{property.Name}", value.ToString() ?? string.Empty);
-                    }
+                    continue;
                 }
+
+                object? propertyValue = property.GetValue(this);
+                if (propertyValue is null)
+                {
+                    continue;
+                }
+
+                const string isoDateTimeFormat = "yyyy'-'MM'-'dd'T'HH':'mm':'ss.FFFFFFFK";
+
+                string value = propertyValue switch
+                {
+                    DateTimeOffset dateTimeOffset => dateTimeOffset.ToString(isoDateTimeFormat, CultureInfo.InvariantCulture),
+                    _ => Convert.ToString(propertyValue, CultureInfo.InvariantCulture) ?? string.Empty,
+                };
+
+                variables.Add($"NBGV_{property.Name}", value);
             }
 
             return variables;


### PR DESCRIPTION
As mentioned in https://github.com/dotnet/Nerdbank.GitVersioning/pull/876#discussion_r1060418125, the formatting of the `CloudBuildAllVars` values used the current culture and didn't specify a format for date values, causing the format to change based on the current culture and not be consistent (between systems/build servers).

Although currently only the `GitCommitDate` value is affected, I've ensured the code also uses the invariant culture for other types (e.g. in case a decimal value is added in the future). I've also ignored the `VersionOptions` property, since that isn't a simple value type and other complex values aren't outputted as well (like `BuildMetadataWithCommitId` and `BuildMetadata`).

Before this PR, `nbgv.exe get-version -f json` would output the following:
```json
{
  // ...
  "CloudBuildAllVars": {
    "NBGV_CloudBuildNumber": "3.6.72-alpha",
    "NBGV_VersionFileFound": "True",
    "NBGV_VersionOptions": "Nerdbank.GitVersioning.VersionOptions",
    "NBGV_AssemblyVersion": "3.6.72.10058",
    "NBGV_AssemblyFileVersion": "3.6.72.10058",
    "NBGV_AssemblyInformationalVersion": "3.6.72-alpha+274a42ed33",
    "NBGV_PublicRelease": "True",
    "NBGV_PrereleaseVersion": "-alpha",
    "NBGV_PrereleaseVersionNoLeadingHyphen": "alpha",
    "NBGV_SimpleVersion": "3.6.72",
    "NBGV_BuildNumber": "72",
    "NBGV_VersionRevision": "10058",
    "NBGV_MajorMinorVersion": "3.6",
    "NBGV_VersionMajor": "3",
    "NBGV_VersionMinor": "6",
    "NBGV_GitCommitId": "274a42ed3321bcc43632dc970d65677f99a486a9",
    "NBGV_GitCommitIdShort": "274a42ed33",
    "NBGV_GitCommitDate": "5-12-2022 23:22:02 +00:00",
    "NBGV_VersionHeight": "72",
    "NBGV_VersionHeightOffset": "0",
    "NBGV_BuildingRef": "refs/heads/main",
    "NBGV_Version": "3.6.72.10058",
    "NBGV_BuildMetadataFragment": "+274a42ed33",
    "NBGV_NuGetPackageVersion": "3.6.72-alpha",
    "NBGV_ChocolateyPackageVersion": "3.6.72-alpha",
    "NBGV_NpmPackageVersion": "3.6.72-alpha",
    "NBGV_SemVer1": "3.6.72-alpha",
    "NBGV_SemVer2": "3.6.72-alpha",
    "NBGV_SemVer1NumericIdentifierPadding": "4"
  },
  // ...
}
```

With this PR applied, you'll notice the `NBGV_VersionOptions` is not present anymore and `NBGV_GitCommitDate` contains an ISO 8601 date format:
```json
{
  // ...
  "CloudBuildAllVars": {
    "NBGV_CloudBuildNumber": "3.6.73-alpha+03e9883256",
    "NBGV_VersionFileFound": "True",
    "NBGV_AssemblyVersion": "3.6.73.1001",
    "NBGV_AssemblyFileVersion": "3.6.73.1001",
    "NBGV_AssemblyInformationalVersion": "3.6.73-alpha+03e9883256",
    "NBGV_PublicRelease": "False",
    "NBGV_PrereleaseVersion": "-alpha",
    "NBGV_PrereleaseVersionNoLeadingHyphen": "alpha",
    "NBGV_SimpleVersion": "3.6.73",
    "NBGV_BuildNumber": "73",
    "NBGV_VersionRevision": "1001",
    "NBGV_MajorMinorVersion": "3.6",
    "NBGV_VersionMajor": "3",
    "NBGV_VersionMinor": "6",
    "NBGV_GitCommitId": "03e988325666cd92193afb2ce5b10688276d9ee3",
    "NBGV_GitCommitIdShort": "03e9883256",
    "NBGV_GitCommitDate": "2023-01-04T09:22:10+00:00",
    "NBGV_VersionHeight": "73",
    "NBGV_VersionHeightOffset": "0",
    "NBGV_BuildingRef": "refs/heads/feature/cloudbuildallvars-formatting",
    "NBGV_Version": "3.6.73.1001",
    "NBGV_BuildMetadataFragment": "+03e9883256",
    "NBGV_NuGetPackageVersion": "3.6.73-alpha-g03e9883256",
    "NBGV_ChocolateyPackageVersion": "3.6.73-alpha-g03e9883256",
    "NBGV_NpmPackageVersion": "3.6.73-alpha.g03e9883256",
    "NBGV_SemVer1": "3.6.73-alpha-03e9883256",
    "NBGV_SemVer2": "3.6.73-alpha.g03e9883256",
    "NBGV_SemVer1NumericIdentifierPadding": "4"
  },
  // ...
}
```