### PR TITLE
Fix: Avoid Shallow Cloning in PerfTests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -101,6 +101,8 @@ stages:
     pool:
       vmImage: $(imageName)
     steps:
+    - checkout: self
+      fetchDepth: 0 # avoid shallow clone so nbgv can do its work.
     - task: UseDotNet@2
       displayName: Install .NET 6.0.403 SDK
       inputs:


### PR DESCRIPTION
Avoid shallow cloning in Azure Pipelines for PerfTests. This does not pop up in the main repo because the Pipeline already existed in Azure Pipelines [when shallow cloning was introduced for new pipelines](https://github.com/dotnet/Nerdbank.GitVersioning/blob/main/doc/cloudbuild.md#azure-pipelines). When using the same pipeline definition for a new pipeline, e.g. for testing stuff in a fork, the PerfTests can not run because the build fails due to the shallow clone.