### PR TITLE
Fix break in Azure Pipelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ It is highly recommended that anyone contributing to this library use the same
 software.
 
 1. [Visual Studio 2019][VS]
-2. [Node.js][NodeJs]
+2. [Node.js][NodeJs] v16 (v18 breaks our build)
 
 ### Optional additional software
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -72,6 +72,10 @@ stages:
         packageType: sdk
         version: 6.0.100
 
+    - task: NodeTool@0
+      inputs:
+        versionSpec: 16.x
+      displayName: ⚙️ Install Node.js
 
     - pwsh: |
         Invoke-WebRequest -Uri "https://dot.net/v1/dotnet-install.ps1" -OutFile dotnet-install.ps1


### PR DESCRIPTION
Some changes in the software on Azure Pipelines hosted agents broke the Nerdbank.GitVersioning build. This PR gets it building again.