### PR TITLE
.NET documentation starter example include

### DIFF
--- a/doc/dotnet.md
+++ b/doc/dotnet.md
@@ -39,3 +39,21 @@ internal sealed partial class ThisAssembly {
 
 This allows you to actually write source code that can refer to the exact build
 number your assembly will be assigned.
+
+Below is a simple example of how you can access this variables in during runtime.
+```csharp
+class Program
+{
+    static void Main(string[] args)
+    {
+        Console.WriteLine($"{nameof(ThisAssembly.AssemblyConfiguration)}: {ThisAssembly.AssemblyConfiguration}");
+        Console.WriteLine($"{nameof(ThisAssembly.AssemblyFileVersion)}: {ThisAssembly.AssemblyFileVersion}");
+        Console.WriteLine($"{nameof(ThisAssembly.AssemblyInformationalVersion)}: {ThisAssembly.AssemblyInformationalVersion}");
+        Console.WriteLine($"{nameof(ThisAssembly.AssemblyName)}: {ThisAssembly.AssemblyName}");
+        Console.WriteLine($"{nameof(ThisAssembly.AssemblyTitle)}: {ThisAssembly.AssemblyTitle}");
+        Console.WriteLine($"{nameof(ThisAssembly.AssemblyVersion)}: {ThisAssembly.AssemblyVersion}");
+        Console.WriteLine($"{nameof(ThisAssembly.GitCommitId)}: {ThisAssembly.GitCommitId}");
+        Console.WriteLine($"{nameof(ThisAssembly.RootNamespace)}: {ThisAssembly.RootNamespace}");
+    }
+}
+```


### PR DESCRIPTION
include an simple example to help beginners access `ThisAssembly` during runtime