### PR TITLE
Compatibility improvement for WiX Toolset V4 projects.

### DIFF
--- a/src/Nerdbank.GitVersioning.Tasks/build/Nerdbank.GitVersioning.targets
+++ b/src/Nerdbank.GitVersioning.Tasks/build/Nerdbank.GitVersioning.targets
@@ -40,6 +40,9 @@
       <GenerateAssemblyVersionInfo Condition=" '$(GenerateAssemblyVersionInfo)' == '' and '$(TargetExt)' != '.dll' and '$(TargetExt)' != '.exe' ">false</GenerateAssemblyVersionInfo>
       <GenerateAssemblyVersionInfo Condition=" '$(GenerateAssemblyVersionInfo)' == '' and '$(NBGV_CacheMode)' == 'VersionGenerationTarget' ">false</GenerateAssemblyVersionInfo>
 
+      <!-- Suppress assembly version info generation for WiX Toolset project. -->
+      <GenerateAssemblyVersionInfo Condition=" '$(GenerateAssemblyVersionInfo)' == '' and '$(Language)' == 'wix' ">false</GenerateAssemblyVersionInfo>
+
       <!-- Workaround the property stomping that msbuild does (see https://github.com/microsoft/msbuild/pull/4922) with manual imports. -->
       <PrepareForBuildDependsOn>
         GenerateNativeNBGVVersionInfo;


### PR DESCRIPTION
In WiX Toolset projects the language is set to _wix_, in these cases the _GenerateAssemblyVersionInfo_ is set to false.

Fixes #913