### PR TITLE
Fix BitBucket handling of publicReleaseRefSpec

### DIFF
--- a/src/NerdBank.GitVersioning/CloudBuildServices/BitbucketCloud.cs
+++ b/src/NerdBank.GitVersioning/CloudBuildServices/BitbucketCloud.cs
@@ -20,10 +20,10 @@ public class BitbucketCloud : ICloudBuild
     public bool IsPullRequest => !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("BITBUCKET_PR_ID"));
 
     /// <inheritdoc />
-    public string BuildingBranch => Environment.GetEnvironmentVariable("BITBUCKET_BRANCH");
+    public string BuildingBranch => CloudBuild.ShouldStartWith(Environment.GetEnvironmentVariable("BITBUCKET_BRANCH"), "refs/heads/");
 
     /// <inheritdoc />
-    public string BuildingTag => Environment.GetEnvironmentVariable("BITBUCKET_TAG");
+    public string BuildingTag => CloudBuild.ShouldStartWith(Environment.GetEnvironmentVariable("BITBUCKET_TAG"), "refs/tags/");
 
     /// <inheritdoc />
     public string GitCommitId => Environment.GetEnvironmentVariable("BITBUCKET_COMMIT");


### PR DESCRIPTION
BitBucket environment variables do not include the `refs/` prefix, so we need to add them ourselves (as we do for some other cloud build services already).

Fixes #935