### PR TITLE
Downgrade Cake.Core to v2.3.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageVersion Include="BenchmarkDotNet.Diagnostics.Windows" Version="$(BenchmarkDotNetVersion)" />
     <PackageVersion Include="BenchmarkDotNet" Version="$(BenchmarkDotNetVersion)" />
-    <PackageVersion Include="Cake.Core" Version="3.0.0" />
+    <PackageVersion Include="Cake.Core" Version="2.3.0" />
     <PackageVersion Include="DotNetMDDocs" Version="0.112.39" />
     <PackageVersion Include="LibGit2Sharp" Version="0.27.0-preview-0182" />
     <PackageVersion Include="Microsoft.Build.Framework" Version="$(MSBuildPackageVersion)" />


### PR DESCRIPTION
This fixes a regression of 3.6.99-alpha+56b1dacf89, Cake v2.x wasn't supported anymore

Fixes #934