### PR TITLE
Retarget from net462 to net472

### DIFF
--- a/src/NerdBank.GitVersioning/ManagedGit/GitPackDeltafiedStream.cs
+++ b/src/NerdBank.GitVersioning/ManagedGit/GitPackDeltafiedStream.cs
@@ -65,7 +65,7 @@ public class GitPackDeltafiedStream : Stream
         set => throw new NotImplementedException();
     }
 
-#if NETSTANDARD2_0
+#if NETFRAMEWORK
     /// <summary>
     /// Reads a sequence of bytes from the current <see cref="GitPackDeltafiedStream"/> and advances the position
     /// within the stream by the number of bytes read.

--- a/src/NerdBank.GitVersioning/ManagedGit/GitPackMemoryCacheStream.cs
+++ b/src/NerdBank.GitVersioning/ManagedGit/GitPackMemoryCacheStream.cs
@@ -44,7 +44,7 @@ internal class GitPackMemoryCacheStream : Stream
         throw new NotSupportedException();
     }
 
-#if NETSTANDARD2_0
+#if NETFRAMEWORK
     public int Read(Span<byte> buffer)
 #else
     /// <inheritdoc/>

--- a/src/NerdBank.GitVersioning/ManagedGit/GitPackMemoryCacheViewStream.cs
+++ b/src/NerdBank.GitVersioning/ManagedGit/GitPackMemoryCacheViewStream.cs
@@ -42,7 +42,7 @@ internal class GitPackMemoryCacheViewStream : Stream
         return this.Read(buffer.AsSpan(offset, count));
     }
 
-#if NETSTANDARD2_0
+#if NETFRAMEWORK
     public int Read(Span<byte> buffer)
 #else
     /// <inheritdoc/>

--- a/src/NerdBank.GitVersioning/ManagedGit/GitPackPooledStream.cs
+++ b/src/NerdBank.GitVersioning/ManagedGit/GitPackPooledStream.cs
@@ -62,7 +62,7 @@ public class GitPackPooledStream : Stream
         this.stream.Flush();
     }
 
-#if !NETSTANDARD2_0
+#if NET6_0_OR_GREATER
     /// <inheritdoc/>
     public override int Read(Span<byte> buffer)
     {

--- a/src/NerdBank.GitVersioning/ManagedGit/GitRepository.cs
+++ b/src/NerdBank.GitVersioning/ManagedGit/GitRepository.cs
@@ -668,7 +668,7 @@ public class GitRepository : IDisposable
 
     private static string TrimEndingDirectorySeparator(string path)
     {
-#if NETSTANDARD2_0
+#if NETFRAMEWORK
         if (string.IsNullOrEmpty(path) || path.Length == 1)
         {
             return path;
@@ -699,7 +699,7 @@ public class GitRepository : IDisposable
         Requires.Argument(data.Length == hexString.Length / 2, nameof(data), "Length must be exactly half that of " + nameof(hexString) + ".");
         for (int index = 0; index < data.Length; index++)
         {
-#if !NETSTANDARD2_0
+#if NET6_0_OR_GREATER
             ReadOnlySpan<char> byteValue = hexString.AsSpan(index * 2, 2);
             if (!byte.TryParse(byteValue, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out data[index]))
             {

--- a/src/NerdBank.GitVersioning/ManagedGit/MemoryMappedStream.cs
+++ b/src/NerdBank.GitVersioning/ManagedGit/MemoryMappedStream.cs
@@ -73,7 +73,7 @@ public unsafe class MemoryMappedStream : Stream
         return read;
     }
 
-#if !NETSTANDARD2_0
+#if NET6_0_OR_GREATER
     /// <inheritdoc/>
     public override int Read(Span<byte> buffer)
     {

--- a/src/NerdBank.GitVersioning/ManagedGit/StreamExtensions.cs
+++ b/src/NerdBank.GitVersioning/ManagedGit/StreamExtensions.cs
@@ -78,7 +78,7 @@ public static class StreamExtensions
         return value;
     }
 
-#if NETSTANDARD2_0
+#if NETFRAMEWORK
     /// <summary>
     /// Reads a sequence of bytes from the current stream and advances the position within the stream by
     /// the number of bytes read.

--- a/src/NerdBank.GitVersioning/ManagedGit/ZLibStream.cs
+++ b/src/NerdBank.GitVersioning/ManagedGit/ZLibStream.cs
@@ -92,7 +92,7 @@ public class ZLibStream : Stream
         return read;
     }
 
-#if !NETSTANDARD2_0
+#if NET6_0_OR_GREATER
     /// <inheritdoc/>
     public override int Read(Span<byte> buffer)
     {
@@ -110,7 +110,7 @@ public class ZLibStream : Stream
         return read;
     }
 
-#if !NETSTANDARD2_0
+#if NET6_0_OR_GREATER
     /// <inheritdoc/>
     public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
     {

--- a/src/NerdBank.GitVersioning/Nerdbank.GitVersioning.csproj
+++ b/src/NerdBank.GitVersioning/Nerdbank.GitVersioning.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <DebugType>Full</DebugType>
     <IsPackable>false</IsPackable>

--- a/src/Nerdbank.GitVersioning.Tasks/AssemblyVersionInfo.cs
+++ b/src/Nerdbank.GitVersioning.Tasks/AssemblyVersionInfo.cs
@@ -37,7 +37,7 @@ namespace Nerdbank.GitVersioning.Tasks
 ------------------------------------------------------------------------------
 ";
 
-#if NET462
+#if NETFRAMEWORK
         private static readonly CodeGeneratorOptions CodeGeneratorOptions = new CodeGeneratorOptions
         {
             BlankLinesBetweenMembers = false,
@@ -136,7 +136,7 @@ namespace Nerdbank.GitVersioning.Tasks
             return null;
         }
 
-#if NET462
+#if NETFRAMEWORK
         /// <inheritdoc/>
         public override bool Execute()
         {
@@ -186,7 +186,7 @@ namespace Nerdbank.GitVersioning.Tasks
         }
 #endif
 
-#if !NET462
+#if !NETFRAMEWORK
         /// <inheritdoc/>
         public override bool Execute()
         {
@@ -233,7 +233,7 @@ namespace Nerdbank.GitVersioning.Tasks
             }
         }
 
-#if NET462
+#if NETFRAMEWORK
         private static CodeMemberField CreateField<T>(string name, T value)
         {
             return new CodeMemberField(typeof(T), name)

--- a/src/Nerdbank.GitVersioning.Tasks/NativeVersionInfo.cs
+++ b/src/Nerdbank.GitVersioning.Tasks/NativeVersionInfo.cs
@@ -177,7 +177,7 @@ END
             {
                 if (!int.TryParse(this.AssemblyLanguage, out lcid))
                 {
-#if NET462
+#if NETFRAMEWORK
                     try
                     {
                         var cultureInfo = new CultureInfo(this.AssemblyLanguage);

--- a/src/Nerdbank.GitVersioning.Tasks/Nerdbank.GitVersioning.Tasks.csproj
+++ b/src/Nerdbank.GitVersioning.Tasks/Nerdbank.GitVersioning.Tasks.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net462;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 
     <NuSpecFile>Nerdbank.GitVersioning.nuspec</NuSpecFile>
@@ -41,16 +41,13 @@
   </ItemDefinitionGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Build.Tasks.Core" />
     <PackageReference Include="Nerdbank.GitVersioning.LKG" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NerdBank.GitVersioning\Nerdbank.GitVersioning.csproj" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net462' ">
-    <PackageReference Include="Microsoft.Build.Tasks.Core" />
-  </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="Microsoft.Build.Tasks.Core" />
     <PackageReference Include="System.Runtime.Loader" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Nerdbank.GitVersioning.Tasks/Nerdbank.GitVersioning.Tasks.targets
+++ b/src/Nerdbank.GitVersioning.Tasks/Nerdbank.GitVersioning.Tasks.targets
@@ -10,7 +10,7 @@
   <Target Name="PackBuildOutputs" DependsOnTargets="SatelliteDllsProjectOutputGroup;DebugSymbolsProjectOutputGroup">
     <PropertyGroup>
       <BuildSubDir Condition=" '$(TargetFramework)' == 'net6.0' ">MSBuildCore\</BuildSubDir>
-      <BuildSubDir Condition=" '$(TargetFramework)' == 'net462' ">MSBuildFull\</BuildSubDir>
+      <BuildSubDir Condition=" '$(TargetFramework)' == 'net472' ">MSBuildFull\</BuildSubDir>
     </PropertyGroup>
     <Error Text="Unrecognized TargetFramework" Condition=" '$(BuildSubDir)' == '' " />
     <ItemGroup>

--- a/src/Nerdbank.GitVersioning.Tasks/Nerdbank.GitVersioning.nuspec
+++ b/src/Nerdbank.GitVersioning.Tasks/Nerdbank.GitVersioning.nuspec
@@ -17,18 +17,18 @@ IMPORTANT: The 3.x release may produce a different version height than prior maj
     <repository type="git" url="https://github.com/dotnet/Nerdbank.GitVersioning.git" commit="$commit$" />
   </metadata>
   <files>
-    <file src="$BaseOutputPath$net462\LibGit2Sharp.dll" target="build\MSBuildFull\LibGit2Sharp.dll" />
-    <file src="$BaseOutputPath$net462\LibGit2Sharp.dll.config" target="build\MSBuildFull\LibGit2Sharp.dll.config" />
-    <file src="$BaseOutputPath$net462\Microsoft.DotNet.PlatformAbstractions.dll" target="build\MSBuildFull\Microsoft.DotNet.PlatformAbstractions.dll" />
-    <file src="$BaseOutputPath$net462\Nerdbank.GitVersioning.dll" target="build\MSBuildFull\Nerdbank.GitVersioning.dll" />
-    <file src="$BaseOutputPath$net462\Nerdbank.GitVersioning.Tasks.dll" target="build\MSBuildFull\Nerdbank.GitVersioning.Tasks.dll" />
-    <file src="$BaseOutputPath$net462\Newtonsoft.Json.dll" target="build\MSBuildFull\Newtonsoft.Json.dll" />
-    <file src="$BaseOutputPath$net462\System.Buffers.dll" target="build\MSBuildFull\System.Buffers.dll" />
-    <file src="$BaseOutputPath$net462\System.Memory.dll" target="build\MSBuildFull\System.Memory.dll" />
-    <file src="$BaseOutputPath$net462\System.Numerics.Vectors.dll" target="build\MSBuildFull\System.Numerics.Vectors.dll" />
-    <file src="$BaseOutputPath$net462\System.Runtime.CompilerServices.Unsafe.dll" target="build\MSBuildFull\System.Runtime.CompilerServices.Unsafe.dll" />
-    <file src="$BaseOutputPath$net462\System.Text.Json.dll" target="build\MSBuildFull\System.Text.Json.dll" />
-    <file src="$BaseOutputPath$net462\Validation.dll" target="build\MSBuildFull\Validation.dll" />
+    <file src="$BaseOutputPath$net472\LibGit2Sharp.dll" target="build\MSBuildFull\LibGit2Sharp.dll" />
+    <file src="$BaseOutputPath$net472\LibGit2Sharp.dll.config" target="build\MSBuildFull\LibGit2Sharp.dll.config" />
+    <file src="$BaseOutputPath$net472\Microsoft.DotNet.PlatformAbstractions.dll" target="build\MSBuildFull\Microsoft.DotNet.PlatformAbstractions.dll" />
+    <file src="$BaseOutputPath$net472\Nerdbank.GitVersioning.dll" target="build\MSBuildFull\Nerdbank.GitVersioning.dll" />
+    <file src="$BaseOutputPath$net472\Nerdbank.GitVersioning.Tasks.dll" target="build\MSBuildFull\Nerdbank.GitVersioning.Tasks.dll" />
+    <file src="$BaseOutputPath$net472\Newtonsoft.Json.dll" target="build\MSBuildFull\Newtonsoft.Json.dll" />
+    <file src="$BaseOutputPath$net472\System.Buffers.dll" target="build\MSBuildFull\System.Buffers.dll" />
+    <file src="$BaseOutputPath$net472\System.Memory.dll" target="build\MSBuildFull\System.Memory.dll" />
+    <file src="$BaseOutputPath$net472\System.Numerics.Vectors.dll" target="build\MSBuildFull\System.Numerics.Vectors.dll" />
+    <file src="$BaseOutputPath$net472\System.Runtime.CompilerServices.Unsafe.dll" target="build\MSBuildFull\System.Runtime.CompilerServices.Unsafe.dll" />
+    <file src="$BaseOutputPath$net472\System.Text.Json.dll" target="build\MSBuildFull\System.Text.Json.dll" />
+    <file src="$BaseOutputPath$net472\Validation.dll" target="build\MSBuildFull\Validation.dll" />
     <file src="$LibGit2SharpNativeBinaries$runtimes\**" target="build\runtimes\" />
 
     <!-- Additional copies to work around DllNotFoundException on Mono (https://github.com/dotnet/Nerdbank.GitVersioning/issues/222) -->

--- a/test/Nerdbank.GitVersioning.Benchmarks/GetVersionBenchmarks.cs
+++ b/test/Nerdbank.GitVersioning.Benchmarks/GetVersionBenchmarks.cs
@@ -10,7 +10,7 @@ using BenchmarkDotNet.Jobs;
 namespace Nerdbank.GitVersioning.Benchmarks
 {
     [SimpleJob(RuntimeMoniker.Net70)]
-    [SimpleJob(RuntimeMoniker.Net462, baseline: true)]
+    [SimpleJob(RuntimeMoniker.Net472, baseline: true)]
     public class GetVersionBenchmarks
     {
         // You must manually clone these repositories:

--- a/test/Nerdbank.GitVersioning.Benchmarks/Nerdbank.GitVersioning.Benchmarks.csproj
+++ b/test/Nerdbank.GitVersioning.Benchmarks/Nerdbank.GitVersioning.Benchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net7.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net462</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net472</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PlatformTarget>AnyCPU</PlatformTarget>


### PR DESCRIPTION
This allows us to update our libgit2sharp dependency. And while projects that use NB.GV may *target* net462 without a problem, NB.GV requiring that build machines have at least net472 installed seems totally reasonable.