### PR TITLE
Make GitPackCache include ObjectType

### DIFF
--- a/src/NerdBank.GitVersioning/ManagedGit/GitPack.cs
+++ b/src/NerdBank.GitVersioning/ManagedGit/GitPack.cs
@@ -221,7 +221,7 @@ public class GitPack : IDisposable
             throw;
         }
 
-        return this.cache.Add(offset, objectType, objectStream);
+        return this.cache.Add(offset, objectStream, objectType);
     }
 
     /// <summary>

--- a/src/NerdBank.GitVersioning/ManagedGit/GitPack.cs
+++ b/src/NerdBank.GitVersioning/ManagedGit/GitPack.cs
@@ -178,7 +178,7 @@ public class GitPack : IDisposable
         }
 #endif
 
-        if (this.cache.TryOpen(offset, out Stream? stream))
+        if (this.cache.TryOpen(offset, objectType, out Stream? stream))
         {
             return stream!;
         }
@@ -216,7 +216,7 @@ public class GitPack : IDisposable
             throw;
         }
 
-        return this.cache.Add(offset, objectStream);
+        return this.cache.Add(offset, objectType, objectStream);
     }
 
     /// <summary>

--- a/src/NerdBank.GitVersioning/ManagedGit/GitPack.cs
+++ b/src/NerdBank.GitVersioning/ManagedGit/GitPack.cs
@@ -178,9 +178,14 @@ public class GitPack : IDisposable
         }
 #endif
 
-        if (this.cache.TryOpen(offset, objectType, out Stream? stream))
+        if (this.cache.TryOpen(offset, out (Stream ContentStream, string ObjectType)? hit))
         {
-            return stream!;
+            if (hit.Value.ObjectType != objectType)
+            {
+                throw new GitException($"An object of type {objectType} could not be located at offset {offset}.") { ErrorCode = GitException.ErrorCodes.ObjectNotFound };
+            }
+
+            return hit.Value.ContentStream;
         }
 
         GitPackObjectType packObjectType;

--- a/src/NerdBank.GitVersioning/ManagedGit/GitPackCache.cs
+++ b/src/NerdBank.GitVersioning/ManagedGit/GitPackCache.cs
@@ -22,6 +22,7 @@ public abstract class GitPackCache : IDisposable
     /// <param name="offset">
     /// The offset of the Git object in the Git pack.
     /// </param>
+    /// <param name="objectType">The object type of the object to retrieve.</param>
     /// <param name="stream">
     /// A <see cref="Stream"/> which will be set to the cached Git object.
     /// </param>
@@ -29,7 +30,7 @@ public abstract class GitPackCache : IDisposable
     /// <see langword="true"/> if the object was found in cache; otherwise,
     /// <see langword="false"/>.
     /// </returns>
-    public abstract bool TryOpen(long offset, [NotNullWhen(true)] out Stream? stream);
+    public abstract bool TryOpen(long offset, string objectType, [NotNullWhen(true)] out Stream? stream);
 
     /// <summary>
     /// Gets statistics about the cache usage.
@@ -45,6 +46,7 @@ public abstract class GitPackCache : IDisposable
     /// <param name="offset">
     /// The offset of the Git object in the Git pack.
     /// </param>
+    /// <param name="objectType">The object type of the object to add to the cache.</param>
     /// <param name="stream">
     /// A <see cref="Stream"/> which represents the object to add. This stream
     /// will be copied to the cache.
@@ -52,7 +54,7 @@ public abstract class GitPackCache : IDisposable
     /// <returns>
     /// A <see cref="Stream"/> which represents the cached entry.
     /// </returns>
-    public abstract Stream Add(long offset, Stream stream);
+    public abstract Stream Add(long offset, string objectType, Stream stream);
 
     /// <inheritdoc/>
     public void Dispose()

--- a/src/NerdBank.GitVersioning/ManagedGit/GitPackCache.cs
+++ b/src/NerdBank.GitVersioning/ManagedGit/GitPackCache.cs
@@ -45,15 +45,15 @@ public abstract class GitPackCache : IDisposable
     /// <param name="offset">
     /// The offset of the Git object in the Git pack.
     /// </param>
-    /// <param name="objectType">The object type of the object to add to the cache.</param>
     /// <param name="stream">
     /// A <see cref="Stream"/> which represents the object to add. This stream
     /// will be copied to the cache.
     /// </param>
+    /// <param name="objectType">The object type of the object to add to the cache.</param>
     /// <returns>
     /// A <see cref="Stream"/> which represents the cached entry.
     /// </returns>
-    public abstract Stream Add(long offset, string objectType, Stream stream);
+    public abstract Stream Add(long offset, Stream stream, string objectType);
 
     /// <inheritdoc/>
     public void Dispose()

--- a/src/NerdBank.GitVersioning/ManagedGit/GitPackCache.cs
+++ b/src/NerdBank.GitVersioning/ManagedGit/GitPackCache.cs
@@ -22,15 +22,14 @@ public abstract class GitPackCache : IDisposable
     /// <param name="offset">
     /// The offset of the Git object in the Git pack.
     /// </param>
-    /// <param name="objectType">The object type of the object to retrieve.</param>
-    /// <param name="stream">
-    /// A <see cref="Stream"/> which will be set to the cached Git object.
+    /// <param name="hit">
+    /// A (<see cref="Stream"/>, ContentType) tuple which will be set to the cached data if found.
     /// </param>
     /// <returns>
     /// <see langword="true"/> if the object was found in cache; otherwise,
     /// <see langword="false"/>.
     /// </returns>
-    public abstract bool TryOpen(long offset, string objectType, [NotNullWhen(true)] out Stream? stream);
+    public abstract bool TryOpen(long offset, [NotNullWhen(true)] out (Stream ContentStream, string ObjectType)? hit);
 
     /// <summary>
     /// Gets statistics about the cache usage.

--- a/src/NerdBank.GitVersioning/ManagedGit/GitPackMemoryCache.cs
+++ b/src/NerdBank.GitVersioning/ManagedGit/GitPackMemoryCache.cs
@@ -21,33 +21,33 @@ namespace Nerdbank.GitVersioning.ManagedGit;
 ///   twice, it is read from the <see cref="MemoryStream"/>, rather than the underlying <see cref="Stream"/>.
 /// </para>
 /// <para>
-///   <see cref="Add(long, string, Stream)"/> and <see cref="TryOpen(long, string, out Stream?)"/> return <see cref="Stream"/>
+///   <see cref="Add(long, string, Stream)"/> and <see cref="TryOpen(long, out ValueTuple{Stream, string}?)"/> return <see cref="Stream"/>
 ///   objects which may operate on the same underlying <see cref="Stream"/>, but independently maintain
 ///   their state.
 /// </para>
 /// </summary>
 public class GitPackMemoryCache : GitPackCache
 {
-    private readonly Dictionary<(long, string), GitPackMemoryCacheStream> cache = new Dictionary<(long, string), GitPackMemoryCacheStream>();
+    private readonly Dictionary<long, (GitPackMemoryCacheStream, string)> cache = new();
 
     /// <inheritdoc/>
     public override Stream Add(long offset, string objectType, Stream stream)
     {
         var cacheStream = new GitPackMemoryCacheStream(stream);
-        this.cache.Add((offset, objectType), cacheStream);
+        this.cache.Add(offset, (cacheStream, objectType));
         return new GitPackMemoryCacheViewStream(cacheStream);
     }
 
     /// <inheritdoc/>
-    public override bool TryOpen(long offset, string objectType, [NotNullWhen(true)] out Stream? stream)
+    public override bool TryOpen(long offset, [NotNullWhen(true)] out (Stream ContentStream, string ObjectType)? hit)
     {
-        if (this.cache.TryGetValue((offset, objectType), out GitPackMemoryCacheStream? cacheStream))
+        if (this.cache.TryGetValue(offset, out (GitPackMemoryCacheStream Stream, string ObjectType) tuple))
         {
-            stream = new GitPackMemoryCacheViewStream(cacheStream!);
+            hit = (new GitPackMemoryCacheViewStream(tuple.Stream), tuple.ObjectType);
             return true;
         }
 
-        stream = null;
+        hit = null;
         return false;
     }
 
@@ -65,7 +65,7 @@ public class GitPackMemoryCache : GitPackCache
             while (this.cache.Count > 0)
             {
                 var key = this.cache.Keys.First();
-                GitPackMemoryCacheStream? stream = this.cache[key];
+                (GitPackMemoryCacheStream? stream, _) = this.cache[key];
                 stream.Dispose();
                 this.cache.Remove(key);
             }

--- a/src/NerdBank.GitVersioning/ManagedGit/GitPackMemoryCache.cs
+++ b/src/NerdBank.GitVersioning/ManagedGit/GitPackMemoryCache.cs
@@ -21,7 +21,7 @@ namespace Nerdbank.GitVersioning.ManagedGit;
 ///   twice, it is read from the <see cref="MemoryStream"/>, rather than the underlying <see cref="Stream"/>.
 /// </para>
 /// <para>
-///   <see cref="Add(long, string, Stream)"/> and <see cref="TryOpen(long, out ValueTuple{Stream, string}?)"/> return <see cref="Stream"/>
+///   <see cref="Add(long, Stream, string)"/> and <see cref="TryOpen(long, out ValueTuple{Stream, string}?)"/> return <see cref="Stream"/>
 ///   objects which may operate on the same underlying <see cref="Stream"/>, but independently maintain
 ///   their state.
 /// </para>
@@ -31,7 +31,7 @@ public class GitPackMemoryCache : GitPackCache
     private readonly Dictionary<long, (GitPackMemoryCacheStream, string)> cache = new();
 
     /// <inheritdoc/>
-    public override Stream Add(long offset, string objectType, Stream stream)
+    public override Stream Add(long offset, Stream stream, string objectType)
     {
         var cacheStream = new GitPackMemoryCacheStream(stream);
         this.cache.Add(offset, (cacheStream, objectType));

--- a/src/NerdBank.GitVersioning/ManagedGit/GitPackNullCache.cs
+++ b/src/NerdBank.GitVersioning/ManagedGit/GitPackNullCache.cs
@@ -19,13 +19,13 @@ public class GitPackNullCache : GitPackCache
     public static GitPackNullCache Instance { get; } = new GitPackNullCache();
 
     /// <inheritdoc/>
-    public override Stream Add(long offset, Stream stream)
+    public override Stream Add(long offset, string objectType, Stream stream)
     {
         return stream;
     }
 
     /// <inheritdoc/>
-    public override bool TryOpen(long offset, [NotNullWhen(true)] out Stream? stream)
+    public override bool TryOpen(long offset, string objectType, [NotNullWhen(true)] out Stream? stream)
     {
         stream = null;
         return false;

--- a/src/NerdBank.GitVersioning/ManagedGit/GitPackNullCache.cs
+++ b/src/NerdBank.GitVersioning/ManagedGit/GitPackNullCache.cs
@@ -25,9 +25,9 @@ public class GitPackNullCache : GitPackCache
     }
 
     /// <inheritdoc/>
-    public override bool TryOpen(long offset, string objectType, [NotNullWhen(true)] out Stream? stream)
+    public override bool TryOpen(long offset, [NotNullWhen(true)] out (Stream ContentStream, string ObjectType)? hit)
     {
-        stream = null;
+        hit = null;
         return false;
     }
 

--- a/src/NerdBank.GitVersioning/ManagedGit/GitPackNullCache.cs
+++ b/src/NerdBank.GitVersioning/ManagedGit/GitPackNullCache.cs
@@ -19,7 +19,7 @@ public class GitPackNullCache : GitPackCache
     public static GitPackNullCache Instance { get; } = new GitPackNullCache();
 
     /// <inheritdoc/>
-    public override Stream Add(long offset, string objectType, Stream stream)
+    public override Stream Add(long offset, Stream stream, string objectType)
     {
         return stream;
     }

--- a/test/Nerdbank.GitVersioning.Tests/ManagedGit/GitPackMemoryCacheTests.cs
+++ b/test/Nerdbank.GitVersioning.Tests/ManagedGit/GitPackMemoryCacheTests.cs
@@ -21,10 +21,12 @@ public class GitPackMemoryCacheTests
             var cache = new GitPackMemoryCache();
 
             Stream stream1 = cache.Add(0, "anObjectType", stream);
-            Assert.True(cache.TryOpen(0, "anObjectType", out Stream stream2));
+            Assert.True(cache.TryOpen(0, out (Stream ContentStream, string ObjectType)? hit));
+            Assert.True(hit.HasValue);
+            Assert.Equal("anObjectType", hit.Value.ObjectType);
 
             using (stream1)
-            using (stream2)
+            using (Stream stream2 = hit.Value.ContentStream)
             {
                 stream1.Seek(5, SeekOrigin.Begin);
                 Assert.Equal(5, stream1.Position);

--- a/test/Nerdbank.GitVersioning.Tests/ManagedGit/GitPackMemoryCacheTests.cs
+++ b/test/Nerdbank.GitVersioning.Tests/ManagedGit/GitPackMemoryCacheTests.cs
@@ -20,7 +20,7 @@ public class GitPackMemoryCacheTests
         {
             var cache = new GitPackMemoryCache();
 
-            Stream stream1 = cache.Add(0, "anObjectType", stream);
+            Stream stream1 = cache.Add(0, stream, "anObjectType");
             Assert.True(cache.TryOpen(0, out (Stream ContentStream, string ObjectType)? hit));
             Assert.True(hit.HasValue);
             Assert.Equal("anObjectType", hit.Value.ObjectType);

--- a/test/Nerdbank.GitVersioning.Tests/ManagedGit/GitPackMemoryCacheTests.cs
+++ b/test/Nerdbank.GitVersioning.Tests/ManagedGit/GitPackMemoryCacheTests.cs
@@ -20,8 +20,8 @@ public class GitPackMemoryCacheTests
         {
             var cache = new GitPackMemoryCache();
 
-            Stream stream1 = cache.Add(0, stream);
-            Assert.True(cache.TryOpen(0, out Stream stream2));
+            Stream stream1 = cache.Add(0, "anObjectType", stream);
+            Assert.True(cache.TryOpen(0, "anObjectType", out Stream stream2));
 
             using (stream1)
             using (stream2)


### PR DESCRIPTION
See https://github.com/dotnet/Nerdbank.GitVersioning/pull/876#discussion_r1146110974

This adds caching of the determined objectType alongside the object's content. While the approach in d0aa014 seems a bit more straight forward than the one in fafa498, I think it is preferrable to have the contentType as part of the cached value instead of the cache key. Otherwise, repeated requests with a mismatching objectType will not profit from caching.

I thought about adding proper `TryGetObject` implementations as part of this. This turned out to be quite hard to get right though. The topics aren't too closely related too so I think they work as seperate PRs. Because these cache improvements should be sufficient to make #876 work, I decided to split this up and postpone the proper `TryGetObject` implementations.