### PR TITLE
Allow customizing commit message pattern in `prepare-release` command

### DIFF
--- a/doc/nbgv-cli.md
+++ b/doc/nbgv-cli.md
@@ -167,7 +167,7 @@ In that case, the `NewBranch` property will be `null`.
 
 ### Customizing the `prepare-release` commit message
 
-By default, the `prepare-release` command generates commit message with this format "Set version to {version}". So with this new option. You can add a prefix or suffix to the default commit message
+By default, the `prepare-release` command generates a commit message with the format "Set version to {version}". So with this new option, You can add a prefix or suffix to the default commit message (which will replace just the version).
 
 For example, running the following command on `master`
 
@@ -178,9 +178,9 @@ nbgv prepare-release --commit-message-pattern "Custom commit message pattern - {
 So your commit message is going to be this:
 
 ```
-Custom commit message pattern - Set version to '1.0' custom message
+Custom commit message pattern '1.0' custom message
 ```
-**Note:** You must consider that commit message pattern must contain only one {0} and valid commit message characters.
+**Note:** Must include {0} in the pattern to represent the version.
 
 ## Creating a version tag
 

--- a/doc/nbgv-cli.md
+++ b/doc/nbgv-cli.md
@@ -167,9 +167,10 @@ In that case, the `NewBranch` property will be `null`.
 
 ### Customizing the `prepare-release` commit message
 
-By default, the `prepare-release` command generates a commit message with the format "Set version to {version}". So with this new option, You can add a prefix or suffix to the default commit message (which will replace just the version).
+By default, the `prepare-release` command generates a commit message with the format "Set version to {version}".
+A switch allows you to customize the commit message, using `{0}` as a placeholder for the version.
 
-For example, running the following command on `master`
+For example, running the following command:
 
 ```
 nbgv prepare-release --commit-message-pattern "Custom commit message pattern - {0} custom message"
@@ -178,9 +179,8 @@ nbgv prepare-release --commit-message-pattern "Custom commit message pattern - {
 So your commit message is going to be this:
 
 ```
-Custom commit message pattern '1.0' custom message
+Custom commit message pattern - 1.0 custom message
 ```
-**Note:** Must include {0} in the pattern to represent the version.
 
 ## Creating a version tag
 

--- a/doc/nbgv-cli.md
+++ b/doc/nbgv-cli.md
@@ -165,6 +165,23 @@ For each branch, the following properties are provided:
 **Note:** When the current branch is already the release branch for the current version, no new branch will be created.
 In that case, the `NewBranch` property will be `null`.
 
+### Customizing the `prepare-release` commit message
+
+By default, the `prepare-release` command generates commit message with this format "Set version to {version}". So with this new option. You can add a prefix or suffix to the default commit message
+
+For example, running the following command on `master`
+
+```
+nbgv prepare-release --commit-message-pattern "Custom commit message pattern - {0} custom message"
+```
+
+So your commit message is going to be this:
+
+```
+Custom commit message pattern - Set version to '1.0' custom message
+```
+**Note:** You must consider that commit message pattern must contain only one {0} and valid commit message characters.
+
 ## Creating a version tag
 
 The `tag` command automates the task of tagging a commit with a version.

--- a/src/NerdBank.GitVersioning/ReleaseManager.cs
+++ b/src/NerdBank.GitVersioning/ReleaseManager.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation and Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Globalization;
 using LibGit2Sharp;
 using Nerdbank.GitVersioning.LibGit2;
 using Newtonsoft.Json;
@@ -127,10 +128,10 @@ public class ReleaseManager
     /// <param name="outputMode">
     /// The output format to use for writing to stdout.
     /// </param>
-    /// <param name="commitMessagePattern">
-    /// Custom pattern to add a prefix or suffix to the default commit message.
+    /// <param name="unformattedCommitMessage">
+    /// An optional, custom message to use for the commit that sets the new version number. May use <c>{0}</c> to substitute the new version number.
     /// </param>
-    public void PrepareRelease(string projectDirectory, string releaseUnstableTag = null, Version nextVersion = null, VersionOptions.ReleaseVersionIncrement? versionIncrement = null, ReleaseManagerOutputMode outputMode = default, string commitMessagePattern = "{0}")
+    public void PrepareRelease(string projectDirectory, string releaseUnstableTag = null, Version nextVersion = null, VersionOptions.ReleaseVersionIncrement? versionIncrement = null, ReleaseManagerOutputMode outputMode = default, string unformattedCommitMessage = null)
     {
         Requires.NotNull(projectDirectory, nameof(projectDirectory));
 
@@ -171,7 +172,7 @@ public class ReleaseManager
                 this.WriteToOutput(releaseInfo);
             }
 
-            this.UpdateVersion(context, versionOptions.Version, releaseVersion, commitMessagePattern);
+            this.UpdateVersion(context, versionOptions.Version, releaseVersion, unformattedCommitMessage);
             return;
         }
 
@@ -195,7 +196,7 @@ public class ReleaseManager
         // create release branch and update version
         Branch releaseBranch = repository.CreateBranch(releaseBranchName);
         global::LibGit2Sharp.Commands.Checkout(repository, releaseBranch);
-        this.UpdateVersion(context, versionOptions.Version, releaseVersion, commitMessagePattern);
+        this.UpdateVersion(context, versionOptions.Version, releaseVersion, unformattedCommitMessage);
 
         if (outputMode == ReleaseManagerOutputMode.Text)
         {
@@ -204,7 +205,7 @@ public class ReleaseManager
 
         // update version on main branch
         global::LibGit2Sharp.Commands.Checkout(repository, originalBranchName);
-        this.UpdateVersion(context, versionOptions.Version, nextDevVersion, commitMessagePattern);
+        this.UpdateVersion(context, versionOptions.Version, nextDevVersion, unformattedCommitMessage);
 
         if (outputMode == ReleaseManagerOutputMode.Text)
         {
@@ -264,7 +265,7 @@ public class ReleaseManager
         return branchNameFormat.Replace("{version}", versionOptions.Version.Version.ToString());
     }
 
-    private void UpdateVersion(LibGit2Context context, SemanticVersion oldVersion, SemanticVersion newVersion, string commitMessagePattern)
+    private void UpdateVersion(LibGit2Context context, SemanticVersion oldVersion, SemanticVersion newVersion, string unformattedCommitMessage)
     {
         Requires.NotNull(context, nameof(context));
 
@@ -293,15 +294,15 @@ public class ReleaseManager
             // Author a commit only if we effectively changed something.
             if (!context.Repository.Head.Tip.Tree.Equals(context.Repository.Index.WriteToTree()))
             {
-                string commitMessage = this.GetCommitMessage(commitMessagePattern, versionOptions.Version);
+                if (string.IsNullOrEmpty(unformattedCommitMessage))
+                {
+                    unformattedCommitMessage = "Set version to '{0}'";
+                }
+
+                string commitMessage = string.Format(CultureInfo.CurrentCulture, unformattedCommitMessage, versionOptions.Version);
                 context.Repository.Commit(commitMessage, signature, signature, new CommitOptions() { AllowEmptyCommit = false });
             }
         }
-    }
-
-    private string GetCommitMessage(string commitMessagePattern, SemanticVersion version)
-    {
-        return commitMessagePattern == "{0}" ? $"Set version to '{version}'" : string.Format(commitMessagePattern, $"'{version}'");
     }
 
     private Signature GetSignature(Repository repository)

--- a/src/NerdBank.GitVersioning/ReleaseManager.cs
+++ b/src/NerdBank.GitVersioning/ReleaseManager.cs
@@ -130,7 +130,7 @@ public class ReleaseManager
     /// <param name="commitMessagePattern">
     /// Custom pattern to add a prefix or suffix to the default commit message.
     /// </param>
-    public void PrepareRelease(string projectDirectory, string releaseUnstableTag = null, Version nextVersion = null, VersionOptions.ReleaseVersionIncrement? versionIncrement = null, ReleaseManagerOutputMode outputMode = default, string commitMessagePattern = null)
+    public void PrepareRelease(string projectDirectory, string releaseUnstableTag = null, Version nextVersion = null, VersionOptions.ReleaseVersionIncrement? versionIncrement = null, ReleaseManagerOutputMode outputMode = default, string commitMessagePattern = "{0}")
     {
         Requires.NotNull(projectDirectory, nameof(projectDirectory));
 

--- a/src/NerdBank.GitVersioning/ReleaseManager.cs
+++ b/src/NerdBank.GitVersioning/ReleaseManager.cs
@@ -293,10 +293,15 @@ public class ReleaseManager
             // Author a commit only if we effectively changed something.
             if (!context.Repository.Head.Tip.Tree.Equals(context.Repository.Index.WriteToTree()))
             {
-                string commitMessage = string.Format(commitMessagePattern, $"Set version to '{versionOptions.Version}'");
+                string commitMessage = this.GetCommitMessage(commitMessagePattern, versionOptions.Version);
                 context.Repository.Commit(commitMessage, signature, signature, new CommitOptions() { AllowEmptyCommit = false });
             }
         }
+    }
+
+    private string GetCommitMessage(string commitMessagePattern, SemanticVersion version)
+    {
+        return commitMessagePattern == "{0}" ? $"Set version to '{version}'" : string.Format(commitMessagePattern, $"'{version}'");
     }
 
     private Signature GetSignature(Repository repository)

--- a/src/nbgv/Program.cs
+++ b/src/nbgv/Program.cs
@@ -768,11 +768,6 @@ namespace Nerdbank.GitVersioning.Tool
             }
 
             // validate commit message pattern
-            if (string.IsNullOrEmpty(commitMessagePattern))
-            {
-                commitMessagePattern = "{0}";
-            }
-
             if (AreCurlyBracesBalanced(commitMessagePattern))
             {
                 Console.Error.WriteLine("Commit message pattern contains unbalanced curly braces.");

--- a/test/Nerdbank.GitVersioning.Tests/ReleaseManagerTests.cs
+++ b/test/Nerdbank.GitVersioning.Tests/ReleaseManagerTests.cs
@@ -639,9 +639,9 @@ public abstract class ReleaseManagerTests : RepoTestBase
     }
 
     [Theory]
-    [InlineData("1.0-beta", "{0} Custom commit message pattern", "Set version to '1.0' Custom commit message pattern")]
-    [InlineData("1.0-beta", "Custom commit message pattern - {0} custom message", "Custom commit message pattern - Set version to '1.0' custom message")]
-    [InlineData("1.0-beta", "Custom commit message pattern - {0}", "Custom commit message pattern - Set version to '1.0'")]
+    [InlineData("1.0-beta", "{0} Custom commit message pattern", "'1.0' Custom commit message pattern")]
+    [InlineData("1.0-beta", "Custom commit message pattern - {0} custom message", "Custom commit message pattern - '1.0' custom message")]
+    [InlineData("1.0-beta", "Custom commit message pattern - {0}", "Custom commit message pattern - '1.0'")]
     [InlineData("1.0-beta", "{0}", "Set version to '1.0'")]
     public void PrepareRelease_WithCustomCommitMessagePattern(string initialVersion, string commitMessagePattern, string expectedCommitMessage)
     {

--- a/test/Nerdbank.GitVersioning.Tests/ReleaseManagerTests.cs
+++ b/test/Nerdbank.GitVersioning.Tests/ReleaseManagerTests.cs
@@ -639,10 +639,10 @@ public abstract class ReleaseManagerTests : RepoTestBase
     }
 
     [Theory]
-    [InlineData("1.0-beta", "{0} Custom commit message pattern", "'1.0' Custom commit message pattern")]
-    [InlineData("1.0-beta", "Custom commit message pattern - {0} custom message", "Custom commit message pattern - '1.0' custom message")]
-    [InlineData("1.0-beta", "Custom commit message pattern - {0}", "Custom commit message pattern - '1.0'")]
-    [InlineData("1.0-beta", "{0}", "Set version to '1.0'")]
+    [InlineData("1.0-beta", "{0} Custom commit message pattern", "1.0 Custom commit message pattern")]
+    [InlineData("1.0-beta", "Custom commit message pattern - {0} custom message", "Custom commit message pattern - 1.0 custom message")]
+    [InlineData("1.0-beta", "Custom commit message pattern - {0}", "Custom commit message pattern - 1.0")]
+    [InlineData("1.0-beta", "{0}", "1.0")]
     public void PrepareRelease_WithCustomCommitMessagePattern(string initialVersion, string commitMessagePattern, string expectedCommitMessage)
     {
         // Create and configure the repository
@@ -657,7 +657,7 @@ public abstract class ReleaseManagerTests : RepoTestBase
 
         // Run PrepareRelease with the custom commit message pattern
         var releaseManager = new ReleaseManager();
-        releaseManager.PrepareRelease(this.RepoPath, commitMessagePattern: commitMessagePattern);
+        releaseManager.PrepareRelease(this.RepoPath, unformattedCommitMessage: commitMessagePattern);
 
         // Verify that the commit message on the release branch matches the expected pattern
         string releaseBranchName = "v1.0";


### PR DESCRIPTION
By default, the `prepare-release` command generates a commit message with the format "Set version to {version}". So with this new option, You can add a prefix or suffix to the default commit message (which will replace just the version).

For example, running the following command on `master`

```
nbgv prepare-release --commit-message-pattern "Custom commit message pattern - {0} custom message"
```

So your commit message is going to be this:

```
Custom commit message pattern '1.0' custom message
```
**Note:** Must include {0} in the pattern to represent the version.

closes #991 