### PR TITLE
Merge latest Library.Template

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "powershell": {
-      "version": "7.3.6",
+      "version": "7.3.9",
       "commands": [
         "pwsh"
       ]
@@ -15,7 +15,7 @@
       ]
     },
     "dotnet-coverage": {
-      "version": "17.8.6",
+      "version": "17.9.3",
       "commands": [
         "dotnet-coverage"
       ]

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # Refer to https://hub.docker.com/_/microsoft-dotnet-sdk for available versions
-FROM mcr.microsoft.com/dotnet/sdk:7.0.302-jammy
+FROM mcr.microsoft.com/dotnet/sdk:7.0.401-jammy
 
 # Installing mono makes `dotnet test` work without errors even for net472.
 # But installing it takes a long time, so it's excluded by default.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
   ignore:
   # This package has unlisted versions on nuget.org that are not supported. Avoid them.
   - dependency-name: dotnet-format
-    versions: ["6.x", "7.x", "8.x"]
+    versions: ["6.x", "7.x", "8.x", "9.x"]
 - package-ecosystem: npm
   directory: /src/nerdbank-gitversioning.npm
   schedule:

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,7 @@
     <BaseOutputPath Condition=" '$(BaseOutputPath)' == '' ">$(RepoRootPath)bin\$(MSBuildProjectName)\</BaseOutputPath>
     <PackageOutputPath>$(RepoRootPath)bin\Packages\$(Configuration)\</PackageOutputPath>
     <DocumentationRootFolder>$(MSBuildThisFileDirectory)..\wiki\api</DocumentationRootFolder>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>11</LangVersion>
     <!--<Nullable>enable</Nullable>-->
     <ImplicitUsings>enable</ImplicitUsings>
     <AnalysisLevel>latest</AnalysisLevel>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -23,7 +23,7 @@
     <PackageVersion Include="Microsoft.Build" Version="$(MSBuildPackageVersion)" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.6.0" />
     <PackageVersion Include="Microsoft.DotNet.PlatformAbstractions" Version="3.1.6" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageVersion Include="Microsoft.Windows.CsWin32" Version="0.2.206-beta" />
     <PackageVersion Include="Moq" Version="4.18.4" />
     <PackageVersion Include="Nerdbank.GitVersioning.LKG" Version="3.4.173-alpha" />
@@ -38,9 +38,9 @@
     <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="7.0.0" />
     <PackageVersion Include="Validation" Version="2.5.51" />
     <PackageVersion Include="Xunit.Combinatorial" Version="1.6.24" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.0" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.3" />
     <PackageVersion Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageVersion Include="xunit" Version="2.5.0" />
+    <PackageVersion Include="xunit" Version="2.6.1" />
   </ItemGroup>
   <ItemGroup>
     <GlobalPackageReference Include="CSharpIsNullAnalyzer" Version="0.1.495" />

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,7 +28,7 @@ resources:
   - container: jammy70
     image: mcr.microsoft.com/dotnet/sdk:7.0-jammy
   - container: debian
-    image: mcr.microsoft.com/dotnet/sdk:latest
+    image: mcr.microsoft.com/dotnet/sdk:7.0
 
 variables:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -105,10 +105,10 @@ stages:
       clean: true
       submodules: true # keep the warnings quiet about the wiki not being enlisted
     - task: UseDotNet@2
-      displayName: Install .NET 7.0.302 SDK
+      displayName: Install .NET 7.0.401 SDK
       inputs:
         packageType: sdk
-        version: 7.0.302
+        version: 7.0.401
     - script: dotnet --info
       displayName: Show dotnet SDK info
     - bash: |

--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -23,7 +23,7 @@ jobs:
   - template: install-dependencies.yml
   - pwsh: |
       Invoke-WebRequest -Uri "https://dot.net/v1/dotnet-install.ps1" -OutFile dotnet-install.ps1
-      & .\dotnet-install.ps1 -Architecture x86 -Version 7.0.302 -InstallDir "C:\Program Files (x86)\dotnet\" -NoPath -Verbose
+      & .\dotnet-install.ps1 -Architecture x86 -Version 7.0.401 -InstallDir "C:\Program Files (x86)\dotnet\" -NoPath -Verbose
     displayName: ⚙ Install 32-bit .NET SDK and runtimes
 
   - template: dotnet.yml

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "7.0.302",
+    "version": "7.0.401",
     "rollForward": "patch",
     "allowPrerelease": false
   }

--- a/test/Nerdbank.GitVersioning.Tests/MSBuildExtensions.cs
+++ b/test/Nerdbank.GitVersioning.Tests/MSBuildExtensions.cs
@@ -25,7 +25,7 @@ internal static class MSBuildExtensions
                 if (IntPtr.Size == 4)
                 {
                     // 32-bit .NET runtime requires special code to find the x86 SDK (where MSBuild is).
-                    MSBuildLocator.RegisterMSBuildPath(@"C:\Program Files (x86)\dotnet\sdk\7.0.302");
+                    MSBuildLocator.RegisterMSBuildPath(@"C:\Program Files (x86)\dotnet\sdk\7.0.401");
                 }
                 else
                 {


### PR DESCRIPTION
- Bump xunit from 2.5.0 to 2.5.1 (#219)
- Bump xunit.runner.visualstudio from 2.5.0 to 2.5.1 (#220)
- Bump powershell to 7.3.7
- Fix LangVersion at 11
- Bump dotnet-coverage to 17.8.7
- Revert "Bump dotnet-coverage to 17.8.7"
- Bump .NET SDK to 7.0.401
- Bump xunit.runner.visualstudio from 2.5.1 to 2.5.3 (#224)
- Bump dotnet-coverage from 17.8.6 to 17.9.1 (#222)
- Bump powershell from 7.3.7 to 7.3.8 (#221)
- Bump xunit from 2.5.1 to 2.5.2 (#223)
- Bump xunit from 2.5.2 to 2.5.3 (#226)
- Bump dotnet-coverage from 17.9.1 to 17.9.3 (#225)
- Bump powershell from 7.3.8 to 7.3.9 (#227)
- Bump xunit from 2.5.3 to 2.6.1 (#228)
- Ignore `dotnet-format` v9 versions
- Bump Microsoft.NET.Test.Sdk from 17.7.2 to 17.8.0 (#229)
- Apply Directory.Packages.props in Apply-Template.ps1
