### PR TITLE
Make `$(NBGV_ThisAssemblyNamespace)` default to `$(RootNamespace)` as per the docs

### DIFF
--- a/src/Nerdbank.GitVersioning.Tasks/build/Nerdbank.GitVersioning.targets
+++ b/src/Nerdbank.GitVersioning.Tasks/build/Nerdbank.GitVersioning.targets
@@ -119,6 +119,7 @@
     <PropertyGroup>
       <VersionSourceFile>$([MSBuild]::NormalizePath('$(IntermediateOutputPath)', '$(AssemblyName).Version$(DefaultLanguageSourceExtension)'))</VersionSourceFile>
       <NewVersionSourceFile>$(VersionSourceFile).new</NewVersionSourceFile>
+      <NBGV_ThisAssemblyNamespace Condition="'$(NBGV_ThisAssemblyNamespace)' == ''">$(RootNamespace)<NBGV_ThisAssemblyNamespace>
     </PropertyGroup>
     <ItemGroup>
       <AdditionalThisAssemblyFields Include="NuGetPackageVersion" String="$(NuGetPackageVersion)" Condition="'$(NBGV_ThisAssemblyIncludesPackageVersion)' == 'true'" />

--- a/src/Nerdbank.GitVersioning.Tasks/build/Nerdbank.GitVersioning.targets
+++ b/src/Nerdbank.GitVersioning.Tasks/build/Nerdbank.GitVersioning.targets
@@ -119,7 +119,7 @@
     <PropertyGroup>
       <VersionSourceFile>$([MSBuild]::NormalizePath('$(IntermediateOutputPath)', '$(AssemblyName).Version$(DefaultLanguageSourceExtension)'))</VersionSourceFile>
       <NewVersionSourceFile>$(VersionSourceFile).new</NewVersionSourceFile>
-      <NBGV_ThisAssemblyNamespace Condition="'$(NBGV_ThisAssemblyNamespace)' == ''">$(RootNamespace)<NBGV_ThisAssemblyNamespace>
+      <NBGV_ThisAssemblyNamespace Condition="'$(NBGV_ThisAssemblyNamespace)' == ''">$(RootNamespace)</NBGV_ThisAssemblyNamespace>
     </PropertyGroup>
     <ItemGroup>
       <AdditionalThisAssemblyFields Include="NuGetPackageVersion" String="$(NuGetPackageVersion)" Condition="'$(NBGV_ThisAssemblyIncludesPackageVersion)' == 'true'" />

--- a/test/Nerdbank.GitVersioning.Tests/SomeGitBuildIntegrationTests.cs
+++ b/test/Nerdbank.GitVersioning.Tests/SomeGitBuildIntegrationTests.cs
@@ -627,7 +627,7 @@ public abstract class SomeGitBuildIntegrationTests : BuildIntegrationTests
         AssemblyProductAttribute assemblyProduct = assembly.GetCustomAttribute<AssemblyProductAttribute>();
         AssemblyCompanyAttribute assemblyCompany = assembly.GetCustomAttribute<AssemblyCompanyAttribute>();
         AssemblyCopyrightAttribute assemblyCopyright = assembly.GetCustomAttribute<AssemblyCopyrightAttribute>();
-        Type thisAssemblyClass = assembly.GetType("ThisAssembly") ?? assembly.GetType("TestNamespace.ThisAssembly");
+        Type thisAssemblyClass = assembly.GetType("ThisAssembly") ?? assembly.GetType("TestNamespace.TestNamespace.ThisAssembly");
         Assert.NotNull(thisAssemblyClass);
 
         Assert.Equal(new Version(result.AssemblyVersion), assembly.GetName().Version);


### PR DESCRIPTION
Currently, the default for `$(NBGV_ThisAssemblyNamespace)` is empty.

[The docs indicate it should be `$(RootNamespace)`](https://github.com/dotnet/Nerdbank.GitVersioning/blob/0e809cfdd62297a622fed18215b2c82960f27733/doc/msbuild.md?plain=1#L49).