### PR TITLE
AssemblyVersionInfo: Use `global::` for all references to types in `System.*` namespaces.

### DIFF
--- a/src/Nerdbank.GitVersioning.Tasks/AssemblyVersionInfo.cs
+++ b/src/Nerdbank.GitVersioning.Tasks/AssemblyVersionInfo.cs
@@ -247,7 +247,7 @@ namespace Nerdbank.GitVersioning.Tasks
         {
             Requires.NotNullOrEmpty(name, nameof(name));
 
-            ////internal static System.DateTime GitCommitDate => new System.DateTime({ticks}, System.DateTimeKind.Utc);");
+            ////internal static global::System.DateTime GitCommitDate => new global::System.DateTime({ticks}, global::System.DateTimeKind.Utc);");
 
             var property = new CodeMemberProperty()
             {
@@ -294,7 +294,7 @@ namespace Nerdbank.GitVersioning.Tasks
 
             var codeAttributeDeclarationCollection = new CodeAttributeDeclarationCollection();
             codeAttributeDeclarationCollection.Add(new CodeAttributeDeclaration(
-                "System.CodeDom.Compiler.GeneratedCode",
+                "global::System.CodeDom.Compiler.GeneratedCode",
                 new CodeAttributeArgument(new CodePrimitiveExpression(GeneratorName)),
                 new CodeAttributeArgument(new CodePrimitiveExpression(GeneratorVersion))));
             thisAssembly.CustomAttributes = codeAttributeDeclarationCollection;
@@ -718,7 +718,7 @@ namespace Nerdbank.GitVersioning.Tasks
 
             internal override void AddThisAssemblyMember(string name, DateTime value)
             {
-                this.CodeBuilder.AppendLine($"  static member internal {name} = new System.DateTime({value.Ticks}L, System.DateTimeKind.Utc)");
+                this.CodeBuilder.AppendLine($"  static member internal {name} = new global.System.DateTime({value.Ticks}L, global.System.DateTimeKind.Utc)");
             }
 
             internal override void StartAssemblyAttributes()
@@ -728,7 +728,7 @@ namespace Nerdbank.GitVersioning.Tasks
 
             internal override void DeclareAttribute(Type type, string arg)
             {
-                this.CodeBuilder.AppendLine($"[<assembly: {type.FullName}(\"{arg}\")>]");
+                this.CodeBuilder.AppendLine($"[<assembly: global.{type.FullName}(\"{arg}\")>]");
             }
 
             internal override void EndThisAssemblyClass()
@@ -740,10 +740,10 @@ namespace Nerdbank.GitVersioning.Tasks
             {
                 this.CodeBuilder.AppendLine("do()");
                 this.CodeBuilder.AppendLine($"#if {CompilerDefinesAroundGeneratedCodeAttribute}");
-                this.CodeBuilder.AppendLine($"[<System.CodeDom.Compiler.GeneratedCode(\"{GeneratorName}\",\"{GeneratorVersion}\")>]");
+                this.CodeBuilder.AppendLine($"[<global.System.CodeDom.Compiler.GeneratedCode(\"{GeneratorName}\",\"{GeneratorVersion}\")>]");
                 this.CodeBuilder.AppendLine("#endif");
                 this.CodeBuilder.AppendLine($"#if {CompilerDefinesAroundExcludeFromCodeCoverageAttribute}");
-                this.CodeBuilder.AppendLine("[<System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage>]");
+                this.CodeBuilder.AppendLine("[<global.System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage>]");
                 this.CodeBuilder.AppendLine("#endif");
                 this.CodeBuilder.AppendLine("type internal ThisAssembly() =");
             }
@@ -768,7 +768,7 @@ namespace Nerdbank.GitVersioning.Tasks
 
             internal override void DeclareAttribute(Type type, string arg)
             {
-                this.CodeBuilder.AppendLine($"[assembly: {type.FullName}(\"{arg}\")]");
+                this.CodeBuilder.AppendLine($"[assembly: global::{type.FullName}(\"{arg}\")]");
             }
 
             internal override void StartThisAssemblyClass()
@@ -779,10 +779,10 @@ namespace Nerdbank.GitVersioning.Tasks
                 }
 
                 this.CodeBuilder.AppendLine($"#if {CompilerDefinesAroundGeneratedCodeAttribute}");
-                this.CodeBuilder.AppendLine($"[System.CodeDom.Compiler.GeneratedCode(\"{GeneratorName}\",\"{GeneratorVersion}\")]");
+                this.CodeBuilder.AppendLine($"[global::System.CodeDom.Compiler.GeneratedCode(\"{GeneratorName}\",\"{GeneratorVersion}\")]");
                 this.CodeBuilder.AppendLine("#endif");
                 this.CodeBuilder.AppendLine($"#if {CompilerDefinesAroundExcludeFromCodeCoverageAttribute}");
-                this.CodeBuilder.AppendLine("[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]");
+                this.CodeBuilder.AppendLine("[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]");
                 this.CodeBuilder.AppendLine("#endif");
                 this.CodeBuilder.AppendLine("internal static partial class ThisAssembly {");
             }
@@ -799,7 +799,7 @@ namespace Nerdbank.GitVersioning.Tasks
 
             internal override void AddThisAssemblyMember(string name, DateTime value)
             {
-                this.CodeBuilder.AppendLine($"    internal static readonly System.DateTime {name} = new System.DateTime({value.Ticks}L, System.DateTimeKind.Utc);");
+                this.CodeBuilder.AppendLine($"    internal static readonly global::System.DateTime {name} = new global::System.DateTime({value.Ticks}L, global::System.DateTimeKind.Utc);");
             }
 
             internal override void EndThisAssemblyClass()
@@ -832,7 +832,7 @@ namespace Nerdbank.GitVersioning.Tasks
 
             internal override void DeclareAttribute(Type type, string arg)
             {
-                this.CodeBuilder.AppendLine($"<Assembly: {type.FullName}(\"{arg}\")>");
+                this.CodeBuilder.AppendLine($"<Assembly: Global.{type.FullName}(\"{arg}\")>");
             }
 
             internal override void StartThisAssemblyClass()
@@ -843,11 +843,11 @@ namespace Nerdbank.GitVersioning.Tasks
                 }
 
                 this.CodeBuilder.AppendLine($"#If {CompilerDefinesAroundExcludeFromCodeCoverageAttribute.Replace("||", " Or ")} Then");
-                this.CodeBuilder.AppendLine($"<System.CodeDom.Compiler.GeneratedCode(\"{GeneratorName}\",\"{GeneratorVersion}\")>");
-                this.CodeBuilder.AppendLine("<System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage>");
+                this.CodeBuilder.AppendLine($"<Global.System.CodeDom.Compiler.GeneratedCode(\"{GeneratorName}\",\"{GeneratorVersion}\")>");
+                this.CodeBuilder.AppendLine("<Global.System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage>");
                 this.CodeBuilder.AppendLine("Partial Friend NotInheritable Class ThisAssembly");
                 this.CodeBuilder.AppendLine($"#ElseIf {CompilerDefinesAroundGeneratedCodeAttribute.Replace("||", " Or ")} Then");
-                this.CodeBuilder.AppendLine($"<System.CodeDom.Compiler.GeneratedCode(\"{GeneratorName}\",\"{GeneratorVersion}\")>");
+                this.CodeBuilder.AppendLine($"<Global.System.CodeDom.Compiler.GeneratedCode(\"{GeneratorName}\",\"{GeneratorVersion}\")>");
                 this.CodeBuilder.AppendLine("Partial Friend NotInheritable Class ThisAssembly");
                 this.CodeBuilder.AppendLine("#Else");
                 this.CodeBuilder.AppendLine("Partial Friend NotInheritable Class ThisAssembly");
@@ -866,7 +866,7 @@ namespace Nerdbank.GitVersioning.Tasks
 
             internal override void AddThisAssemblyMember(string name, DateTime value)
             {
-                this.CodeBuilder.AppendLine($"    Friend Shared ReadOnly {name} As System.DateTime = New System.DateTime({value.Ticks}L, System.DateTimeKind.Utc)");
+                this.CodeBuilder.AppendLine($"    Friend Shared ReadOnly {name} As Global.System.DateTime = New Global.System.DateTime({value.Ticks}L, Global.System.DateTimeKind.Utc)");
             }
 
             internal override void EndThisAssemblyClass()

--- a/test/Nerdbank.GitVersioning.Tests/AssemblyInfoTest.cs
+++ b/test/Nerdbank.GitVersioning.Tests/AssemblyInfoTest.cs
@@ -63,15 +63,15 @@ public class AssemblyInfoTest : IClassFixture<MSBuildFixture> // The MSBuildFixt
 #nowarn ""CA2243""
 
 namespace AssemblyInfo
-[<assembly: System.Reflection.AssemblyVersionAttribute(""1.3.0.0"")>]
-[<assembly: System.Reflection.AssemblyFileVersionAttribute(""1.3.1.0"")>]
-[<assembly: System.Reflection.AssemblyInformationalVersionAttribute("""")>]
+[<assembly: global.System.Reflection.AssemblyVersionAttribute(""1.3.0.0"")>]
+[<assembly: global.System.Reflection.AssemblyFileVersionAttribute(""1.3.1.0"")>]
+[<assembly: global.System.Reflection.AssemblyInformationalVersionAttribute("""")>]
 {(thisAssemblyClass.GetValueOrDefault(true) ? $@"do()
 #if NETSTANDARD || NETFRAMEWORK || NETCOREAPP
-[<System.CodeDom.Compiler.GeneratedCode(""{AssemblyVersionInfo.GeneratorName}"",""{AssemblyVersionInfo.GeneratorVersion}"")>]
+[<global.System.CodeDom.Compiler.GeneratedCode(""{AssemblyVersionInfo.GeneratorName}"",""{AssemblyVersionInfo.GeneratorVersion}"")>]
 #endif
 #if NET40_OR_GREATER || NETCOREAPP2_0_OR_GREATER || NETSTANDARD2_0_OR_GREATER
-[<System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage>]
+[<global.System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage>]
 #endif
 type internal ThisAssembly() =
   static member internal AssemblyCompany = ""company""
@@ -80,7 +80,7 @@ type internal ThisAssembly() =
   static member internal CustomBool = true
   static member internal CustomString1 = ""abc""
   static member internal CustomString3 = """"
-  static member internal CustomTicks = new System.DateTime(637509805729817056L, System.DateTimeKind.Utc)
+  static member internal CustomTicks = new global.System.DateTime(637509805729817056L, global.System.DateTimeKind.Utc)
   static member internal IsPrerelease = false
   static member internal IsPublicRelease = false
   static member internal RootNamespace = """"
@@ -128,15 +128,15 @@ namespace {(
         : !string.IsNullOrWhiteSpace(rootNamespace)
             ? rootNamespace
             : "AssemblyInfo")}
-[<assembly: System.Reflection.AssemblyVersionAttribute(""1.3.0.0"")>]
-[<assembly: System.Reflection.AssemblyFileVersionAttribute(""1.3.1.0"")>]
-[<assembly: System.Reflection.AssemblyInformationalVersionAttribute("""")>]
+[<assembly: global.System.Reflection.AssemblyVersionAttribute(""1.3.0.0"")>]
+[<assembly: global.System.Reflection.AssemblyFileVersionAttribute(""1.3.1.0"")>]
+[<assembly: global.System.Reflection.AssemblyInformationalVersionAttribute("""")>]
 do()
 #if NETSTANDARD || NETFRAMEWORK || NETCOREAPP
-[<System.CodeDom.Compiler.GeneratedCode(""{AssemblyVersionInfo.GeneratorName}"",""{AssemblyVersionInfo.GeneratorVersion}"")>]
+[<global.System.CodeDom.Compiler.GeneratedCode(""{AssemblyVersionInfo.GeneratorName}"",""{AssemblyVersionInfo.GeneratorVersion}"")>]
 #endif
 #if NET40_OR_GREATER || NETCOREAPP2_0_OR_GREATER || NETSTANDARD2_0_OR_GREATER
-[<System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage>]
+[<global.System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage>]
 #endif
 type internal ThisAssembly() =
   static member internal AssemblyCompany = ""company""
@@ -201,14 +201,14 @@ do()
 
 #pragma warning disable CA2243
 
-[assembly: System.Reflection.AssemblyVersionAttribute(""1.3.0.0"")]
-[assembly: System.Reflection.AssemblyFileVersionAttribute(""1.3.1.0"")]
-[assembly: System.Reflection.AssemblyInformationalVersionAttribute("""")]
+[assembly: global::System.Reflection.AssemblyVersionAttribute(""1.3.0.0"")]
+[assembly: global::System.Reflection.AssemblyFileVersionAttribute(""1.3.1.0"")]
+[assembly: global::System.Reflection.AssemblyInformationalVersionAttribute("""")]
 {(thisAssemblyClass.GetValueOrDefault(true) ? $@"#if NETSTANDARD || NETFRAMEWORK || NETCOREAPP
-[System.CodeDom.Compiler.GeneratedCode(""{AssemblyVersionInfo.GeneratorName}"",""{AssemblyVersionInfo.GeneratorVersion}"")]
+[global::System.CodeDom.Compiler.GeneratedCode(""{AssemblyVersionInfo.GeneratorName}"",""{AssemblyVersionInfo.GeneratorVersion}"")]
 #endif
 #if NET40_OR_GREATER || NETCOREAPP2_0_OR_GREATER || NETSTANDARD2_0_OR_GREATER
-[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 #endif
 internal static partial class ThisAssembly {{
     internal const string AssemblyCompany = ""company"";
@@ -217,7 +217,7 @@ internal static partial class ThisAssembly {{
     internal const bool CustomBool = true;
     internal const string CustomString1 = ""abc"";
     internal const string CustomString3 = """";
-    internal static readonly System.DateTime CustomTicks = new System.DateTime(637509805729817056L, System.DateTimeKind.Utc);
+    internal static readonly global::System.DateTime CustomTicks = new global::System.DateTime(637509805729817056L, global::System.DateTimeKind.Utc);
     internal const bool IsPrerelease = false;
     internal const bool IsPublicRelease = false;
     internal const string RootNamespace = """";
@@ -263,14 +263,14 @@ internal static partial class ThisAssembly {{
 
 #pragma warning disable CA2243
 
-[assembly: System.Reflection.AssemblyVersionAttribute(""1.3.0.0"")]
-[assembly: System.Reflection.AssemblyFileVersionAttribute(""1.3.1.0"")]
-[assembly: System.Reflection.AssemblyInformationalVersionAttribute("""")]{nsStart}
+[assembly: global::System.Reflection.AssemblyVersionAttribute(""1.3.0.0"")]
+[assembly: global::System.Reflection.AssemblyFileVersionAttribute(""1.3.1.0"")]
+[assembly: global::System.Reflection.AssemblyInformationalVersionAttribute("""")]{nsStart}
 #if NETSTANDARD || NETFRAMEWORK || NETCOREAPP
-[System.CodeDom.Compiler.GeneratedCode(""{AssemblyVersionInfo.GeneratorName}"",""{AssemblyVersionInfo.GeneratorVersion}"")]
+[global::System.CodeDom.Compiler.GeneratedCode(""{AssemblyVersionInfo.GeneratorName}"",""{AssemblyVersionInfo.GeneratorVersion}"")]
 #endif
 #if NET40_OR_GREATER || NETCOREAPP2_0_OR_GREATER || NETSTANDARD2_0_OR_GREATER
-[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 #endif
 internal static partial class ThisAssembly {{
     internal const string AssemblyCompany = ""company"";
@@ -316,15 +316,15 @@ internal static partial class ThisAssembly {{
 
 #Disable Warning CA2243
 
-<Assembly: System.Reflection.AssemblyVersionAttribute(""1.3.0.0"")>
-<Assembly: System.Reflection.AssemblyFileVersionAttribute(""1.3.1.0"")>
-<Assembly: System.Reflection.AssemblyInformationalVersionAttribute("""")>
+<Assembly: Global.System.Reflection.AssemblyVersionAttribute(""1.3.0.0"")>
+<Assembly: Global.System.Reflection.AssemblyFileVersionAttribute(""1.3.1.0"")>
+<Assembly: Global.System.Reflection.AssemblyInformationalVersionAttribute("""")>
 {(thisAssemblyClass.GetValueOrDefault(true) ? $@"#If NET40_OR_GREATER  Or  NETCOREAPP2_0_OR_GREATER  Or  NETSTANDARD2_0_OR_GREATER Then
-<System.CodeDom.Compiler.GeneratedCode(""{AssemblyVersionInfo.GeneratorName}"",""{AssemblyVersionInfo.GeneratorVersion}"")>
-<System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage>
+<Global.System.CodeDom.Compiler.GeneratedCode(""{AssemblyVersionInfo.GeneratorName}"",""{AssemblyVersionInfo.GeneratorVersion}"")>
+<Global.System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage>
 Partial Friend NotInheritable Class ThisAssembly
 #ElseIf NETSTANDARD  Or  NETFRAMEWORK  Or  NETCOREAPP Then
-<System.CodeDom.Compiler.GeneratedCode(""{AssemblyVersionInfo.GeneratorName}"",""{AssemblyVersionInfo.GeneratorVersion}"")>
+<Global.System.CodeDom.Compiler.GeneratedCode(""{AssemblyVersionInfo.GeneratorName}"",""{AssemblyVersionInfo.GeneratorVersion}"")>
 Partial Friend NotInheritable Class ThisAssembly
 #Else
 Partial Friend NotInheritable Class ThisAssembly
@@ -377,15 +377,15 @@ End Class
 
 #Disable Warning CA2243
 
-<Assembly: System.Reflection.AssemblyVersionAttribute(""1.3.0.0"")>
-<Assembly: System.Reflection.AssemblyFileVersionAttribute(""1.3.1.0"")>
-<Assembly: System.Reflection.AssemblyInformationalVersionAttribute("""")>{nsStart}
+<Assembly: Global.System.Reflection.AssemblyVersionAttribute(""1.3.0.0"")>
+<Assembly: Global.System.Reflection.AssemblyFileVersionAttribute(""1.3.1.0"")>
+<Assembly: Global.System.Reflection.AssemblyInformationalVersionAttribute("""")>{nsStart}
 #If NET40_OR_GREATER  Or  NETCOREAPP2_0_OR_GREATER  Or  NETSTANDARD2_0_OR_GREATER Then
-<System.CodeDom.Compiler.GeneratedCode(""{AssemblyVersionInfo.GeneratorName}"",""{AssemblyVersionInfo.GeneratorVersion}"")>
-<System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage>
+<Global.System.CodeDom.Compiler.GeneratedCode(""{AssemblyVersionInfo.GeneratorName}"",""{AssemblyVersionInfo.GeneratorVersion}"")>
+<Global.System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage>
 Partial Friend NotInheritable Class ThisAssembly
 #ElseIf NETSTANDARD  Or  NETFRAMEWORK  Or  NETCOREAPP Then
-<System.CodeDom.Compiler.GeneratedCode(""{AssemblyVersionInfo.GeneratorName}"",""{AssemblyVersionInfo.GeneratorVersion}"")>
+<Global.System.CodeDom.Compiler.GeneratedCode(""{AssemblyVersionInfo.GeneratorName}"",""{AssemblyVersionInfo.GeneratorVersion}"")>
 Partial Friend NotInheritable Class ThisAssembly
 #Else
 Partial Friend NotInheritable Class ThisAssembly


### PR DESCRIPTION
This is necessary to avoid lookup errors when a user's `NBGV_ThisAssemblyNamespace` ends with `.System`, and probably other similar situations.