### PR TITLE
Change F# AssemblyInfo generation to always include a do() after the …

### DIFF
--- a/src/Nerdbank.GitVersioning.Tasks/AssemblyVersionInfo.cs
+++ b/src/Nerdbank.GitVersioning.Tasks/AssemblyVersionInfo.cs
@@ -397,6 +397,8 @@ namespace Nerdbank.GitVersioning.Tasks
                     this.generator.DeclareAttribute(typeof(AssemblyCopyrightAttribute), this.AssemblyCopyright);
                 }
             }
+
+            this.generator.EndAssemblyAttributes();
         }
 
         private List<KeyValuePair<string, (object Value, bool EmitIfEmpty /* Only applies to string values */)>> GetFieldsForThisAssembly()
@@ -658,6 +660,10 @@ namespace Nerdbank.GitVersioning.Tasks
             {
             }
 
+            internal virtual void EndAssemblyAttributes()
+            {
+            }
+
             internal abstract void DeclareAttribute(Type type, string arg);
 
             internal abstract void StartThisAssemblyClass();
@@ -726,6 +732,11 @@ namespace Nerdbank.GitVersioning.Tasks
                 this.CodeBuilder.AppendLine($"namespace {this.Namespace}");
             }
 
+            internal override void EndAssemblyAttributes()
+            {
+                this.CodeBuilder.AppendLine("do()");
+            }
+
             internal override void DeclareAttribute(Type type, string arg)
             {
                 this.CodeBuilder.AppendLine($"[<assembly: {type.FullName}(\"{arg}\")>]");
@@ -738,7 +749,6 @@ namespace Nerdbank.GitVersioning.Tasks
 
             internal override void StartThisAssemblyClass()
             {
-                this.CodeBuilder.AppendLine("do()");
                 this.CodeBuilder.AppendLine($"#if {CompilerDefinesAroundGeneratedCodeAttribute}");
                 this.CodeBuilder.AppendLine($"[<System.CodeDom.Compiler.GeneratedCode(\"{GeneratorName}\",\"{GeneratorVersion}\")>]");
                 this.CodeBuilder.AppendLine("#endif");

--- a/test/Nerdbank.GitVersioning.Tests/AssemblyInfoTest.cs
+++ b/test/Nerdbank.GitVersioning.Tests/AssemblyInfoTest.cs
@@ -66,8 +66,8 @@ namespace AssemblyInfo
 [<assembly: System.Reflection.AssemblyVersionAttribute(""1.3.0.0"")>]
 [<assembly: System.Reflection.AssemblyFileVersionAttribute(""1.3.1.0"")>]
 [<assembly: System.Reflection.AssemblyInformationalVersionAttribute("""")>]
-{(thisAssemblyClass.GetValueOrDefault(true) ? $@"do()
-#if NETSTANDARD || NETFRAMEWORK || NETCOREAPP
+do()
+{(thisAssemblyClass.GetValueOrDefault(true) ? $@"#if NETSTANDARD || NETFRAMEWORK || NETCOREAPP
 [<System.CodeDom.Compiler.GeneratedCode(""{AssemblyVersionInfo.GeneratorName}"",""{AssemblyVersionInfo.GeneratorVersion}"")>]
 #endif
 #if NET40_OR_GREATER || NETCOREAPP2_0_OR_GREATER || NETSTANDARD2_0_OR_GREATER


### PR DESCRIPTION
…version attributes

Fixes #1022 

As it stands, assembly version information for F# when ThisAssembly generation is disabled generates things like
![image](https://github.com/dotnet/Nerdbank.GitVersioning/assets/1178570/bca840ed-709a-46f4-ac4e-10646873bc7d)
because the ```do()``` after the attributes is required and isn't added.

There is a unit test for this case, but I don't think it's quite right as it expects the ```do()``` to be a header for the ```#if NETSTANDARD || NETFRAMEWORK || NETCOREAPP``` bit instead of a footer for the assembly version attributes.