### PR TITLE
Merge v3.6 to main

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -17,10 +17,6 @@ Param(
 
 $msbuildCommandLine = "dotnet build `"$PSScriptRoot\Nerdbank.GitVersioning.sln`" /m /verbosity:$MsBuildVerbosity /nologo /p:Platform=`"Any CPU`" /t:build,pack"
 
-if (Test-Path "C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll") {
-    $msbuildCommandLine += " /logger:`"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll`""
-}
-
 if ($Configuration) {
     $msbuildCommandLine += " /p:Configuration=$Configuration"
 }
@@ -31,6 +27,13 @@ try {
         Invoke-Expression $msbuildCommandLine
         if ($LASTEXITCODE -ne 0) {
             throw "dotnet build failed"
+        }
+    }
+
+    if ($PSCmdlet.ShouldProcess('src/nbgv', 'dotnet publish')) {
+        dotnet publish src/nbgv -c $Configuration -o src/nerdbank-gitversioning.npm/out/nbgv.cli/tools/net6.0/any
+        if ($LASTEXITCODE -ne 0) {
+            throw "dotnet publish failed"
         }
     }
 

--- a/src/NerdBank.GitVersioning/CloudBuildServices/BitbucketCloud.cs
+++ b/src/NerdBank.GitVersioning/CloudBuildServices/BitbucketCloud.cs
@@ -20,10 +20,10 @@ public class BitbucketCloud : ICloudBuild
     public bool IsPullRequest => !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("BITBUCKET_PR_ID"));
 
     /// <inheritdoc />
-    public string BuildingBranch => Environment.GetEnvironmentVariable("BITBUCKET_BRANCH");
+    public string BuildingBranch => CloudBuild.ShouldStartWith(Environment.GetEnvironmentVariable("BITBUCKET_BRANCH"), "refs/heads/");
 
     /// <inheritdoc />
-    public string BuildingTag => Environment.GetEnvironmentVariable("BITBUCKET_TAG");
+    public string BuildingTag => CloudBuild.ShouldStartWith(Environment.GetEnvironmentVariable("BITBUCKET_TAG"), "refs/tags/");
 
     /// <inheritdoc />
     public string GitCommitId => Environment.GetEnvironmentVariable("BITBUCKET_COMMIT");

--- a/src/NerdBank.GitVersioning/VersionOracle.cs
+++ b/src/NerdBank.GitVersioning/VersionOracle.cs
@@ -395,7 +395,7 @@ public class VersionOracle
     /// <summary>
     /// Gets the version to use for NPM packages.
     /// </summary>
-    public string NpmPackageVersion => $"{this.Version.ToStringSafe(3)}{this.PrereleaseVersion}";
+    public string NpmPackageVersion => this.SemVer2;
 
     /// <summary>
     /// Gets a SemVer 1.0 compliant string that represents this version, including the -COMMITID suffix

--- a/src/Nerdbank.GitVersioning.Tasks/AssemblyVersionInfo.cs
+++ b/src/Nerdbank.GitVersioning.Tasks/AssemblyVersionInfo.cs
@@ -397,6 +397,8 @@ namespace Nerdbank.GitVersioning.Tasks
                     this.generator.DeclareAttribute(typeof(AssemblyCopyrightAttribute), this.AssemblyCopyright);
                 }
             }
+
+            this.generator.EndAssemblyAttributes();
         }
 
         private List<KeyValuePair<string, (object Value, bool EmitIfEmpty /* Only applies to string values */)>> GetFieldsForThisAssembly()
@@ -658,6 +660,10 @@ namespace Nerdbank.GitVersioning.Tasks
             {
             }
 
+            internal virtual void EndAssemblyAttributes()
+            {
+            }
+
             internal abstract void DeclareAttribute(Type type, string arg);
 
             internal abstract void StartThisAssemblyClass();
@@ -726,6 +732,11 @@ namespace Nerdbank.GitVersioning.Tasks
                 this.CodeBuilder.AppendLine($"namespace {this.Namespace}");
             }
 
+            internal override void EndAssemblyAttributes()
+            {
+                this.CodeBuilder.AppendLine("do()");
+            }
+
             internal override void DeclareAttribute(Type type, string arg)
             {
                 this.CodeBuilder.AppendLine($"[<assembly: global.{type.FullName}(\"{arg}\")>]");
@@ -738,7 +749,6 @@ namespace Nerdbank.GitVersioning.Tasks
 
             internal override void StartThisAssemblyClass()
             {
-                this.CodeBuilder.AppendLine("do()");
                 this.CodeBuilder.AppendLine($"#if {CompilerDefinesAroundGeneratedCodeAttribute}");
                 this.CodeBuilder.AppendLine($"[<global.System.CodeDom.Compiler.GeneratedCode(\"{GeneratorName}\",\"{GeneratorVersion}\")>]");
                 this.CodeBuilder.AppendLine("#endif");

--- a/src/Nerdbank.GitVersioning.Tasks/build/Nerdbank.GitVersioning.targets
+++ b/src/Nerdbank.GitVersioning.Tasks/build/Nerdbank.GitVersioning.targets
@@ -142,6 +142,9 @@
     <PropertyGroup>
       <VersionSourceFile>$([MSBuild]::NormalizePath('$(IntermediateOutputPath)', '$(AssemblyName).Version$(DefaultLanguageSourceExtension)'))</VersionSourceFile>
       <NewVersionSourceFile>$(VersionSourceFile).new</NewVersionSourceFile>
+      <!-- Workaround WPF inner build RootNamespace changing: https://github.com/dotnet/Nerdbank.GitVersioning/issues/175 -->
+      <NBGV_RootNamespace>$(RootNamespace)</NBGV_RootNamespace>
+      <NBGV_RootNamespace Condition="$(RootNamespace.EndsWith('_wpftmp')) and '$(_TargetAssemblyProjectName)'!=''">$(_TargetAssemblyProjectName)</NBGV_RootNamespace>
     </PropertyGroup>
     <ItemGroup>
       <AdditionalThisAssemblyFields Include="NuGetPackageVersion" String="$(NuGetPackageVersion)" Condition="'$(NBGV_ThisAssemblyIncludesPackageVersion)' == 'true'" />
@@ -154,7 +157,7 @@
                   AssemblyFileVersion="$(AssemblyFileVersion)"
                   AssemblyInformationalVersion="$(AssemblyInformationalVersion)"
                   AssemblyName="$(AssemblyName)"
-                  RootNamespace="$(RootNamespace)"
+                  RootNamespace="$(NBGV_RootNamespace)"
                   ThisAssemblyNamespace="$(NBGV_ThisAssemblyNamespace)"
                   AssemblyOriginatorKeyFile="$(AssemblyOriginatorKeyFile)"
                   AssemblyTitle="$(AssemblyTitle)"

--- a/test/Nerdbank.GitVersioning.Tests/AssemblyInfoTest.cs
+++ b/test/Nerdbank.GitVersioning.Tests/AssemblyInfoTest.cs
@@ -66,8 +66,8 @@ namespace AssemblyInfo
 [<assembly: global.System.Reflection.AssemblyVersionAttribute(""1.3.0.0"")>]
 [<assembly: global.System.Reflection.AssemblyFileVersionAttribute(""1.3.1.0"")>]
 [<assembly: global.System.Reflection.AssemblyInformationalVersionAttribute("""")>]
-{(thisAssemblyClass.GetValueOrDefault(true) ? $@"do()
-#if NETSTANDARD || NETFRAMEWORK || NETCOREAPP
+do()
+{(thisAssemblyClass.GetValueOrDefault(true) ? $@"#if NETSTANDARD || NETFRAMEWORK || NETCOREAPP
 [<global.System.CodeDom.Compiler.GeneratedCode(""{AssemblyVersionInfo.GeneratorName}"",""{AssemblyVersionInfo.GeneratorVersion}"")>]
 #endif
 #if NET40_OR_GREATER || NETCOREAPP2_0_OR_GREATER || NETSTANDARD2_0_OR_GREATER


### PR DESCRIPTION
- Revert "Disable package signing"
- Fix BitBucket recognition of publicReleaseRefSpec
- Downgrade Cake.Core to v2.3.0
- Revert "Drop BuildMetadata from NPM package version "
- Fix WPF incremental build
- Fix build.ps1 script
- Change F# AssemblyInfo generation to always include a do() after the version attributes
