### PR TITLE
Switch System.Text.Json to non-vulnerable version

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -31,7 +31,7 @@
     <PackageVersion Include="System.Diagnostics.Tools" Version="4.3.0" />
     <PackageVersion Include="System.Memory" Version="4.5.5" />
     <PackageVersion Include="System.Runtime.Loader" Version="4.3.0" />
-    <PackageVersion Include="System.Text.Json" Version="7.0.2" />
+    <PackageVersion Include="System.Text.Json" Version="6.0.9" />
     <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="7.0.0" />
     <PackageVersion Include="Validation" Version="2.5.51" />
     <PackageVersion Include="Xunit.Combinatorial" Version="1.5.25" />


### PR DESCRIPTION
This switches from the vulnerable and un-fixed 7.0.x versions to the still-supported 6.0.x track. We avoid switching to 8.x because that could complicate anyone still using .NET 7 (which they shouldn't, but this is a servicing fix).

Fixes #1073