### PR TITLE
Merge latest Library.Template

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,19 +3,19 @@
   "isRoot": true,
   "tools": {
     "powershell": {
-      "version": "7.4.2",
+      "version": "7.4.4",
       "commands": [
         "pwsh"
       ]
     },
     "dotnet-coverage": {
-      "version": "17.11.0",
+      "version": "17.11.3",
       "commands": [
         "dotnet-coverage"
       ]
     },
     "nbgv": {
-      "version": "3.6.133",
+      "version": "3.6.139",
       "commands": [
         "nbgv"
       ]

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # Refer to https://hub.docker.com/_/microsoft-dotnet-sdk for available versions
-FROM mcr.microsoft.com/dotnet/sdk:8.0.201-jammy
+FROM mcr.microsoft.com/dotnet/sdk:8.0.300-jammy
 
 # Installing mono makes `dotnet test` work without errors even for net472.
 # But installing it takes a long time, so it's excluded by default.

--- a/.editorconfig
+++ b/.editorconfig
@@ -26,6 +26,7 @@ indent_size = 2
 # Xml config files
 [*.{ruleset,config,nuspec,resx,vsixmanifest,vsct,runsettings}]
 indent_size = 2
+indent_style = space
 
 # JSON files
 [*.json]
@@ -189,6 +190,9 @@ dotnet_diagnostic.DOC202.severity = warning
 
 # CA1062: Validate arguments of public methods
 dotnet_diagnostic.CA1062.severity = suggestion
+
+# CA2016: Forward the CancellationToken parameter
+dotnet_diagnostic.CA2016.severity = warning
 
 [*.sln]
 indent_style = tab

--- a/.gitignore
+++ b/.gitignore
@@ -352,3 +352,6 @@ MigrationBackup/
 
 # mac-created file to track user view preferences for a directory
 .DS_Store
+
+# Analysis results
+*.sarif

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,7 +7,6 @@
     <BaseOutputPath Condition=" '$(BaseOutputPath)' == '' ">$(RepoRootPath)bin\$(MSBuildProjectName)\</BaseOutputPath>
     <PackageOutputPath>$(RepoRootPath)bin\Packages\$(Configuration)\</PackageOutputPath>
     <DocumentationRootFolder>$(MSBuildThisFileDirectory)..\wiki\api</DocumentationRootFolder>
-    <LangVersion>12</LangVersion>
     <!--<Nullable>enable</Nullable>-->
     <ImplicitUsings>enable</ImplicitUsings>
     <AnalysisLevel>latest</AnalysisLevel>
@@ -56,23 +55,4 @@
       <PackageReleaseNotes Condition="'$(PackageProjectUrl)'!=''">$(PackageProjectUrl)/releases/tag/v$(Version)</PackageReleaseNotes>
     </PropertyGroup>
   </Target>
-
-  <PropertyGroup Condition="'$(IsWpfTempProject)' == ''">
-    <IsWpfTempProject>false</IsWpfTempProject>
-    <IsWpfTempProject Condition="$(MSBuildProjectName.EndsWith('_wpftmp'))">true</IsWpfTempProject>
-  </PropertyGroup>
-
-  <!--
-    Inspired by https://github.com/dotnet/arcade/blob/cbfa29d4e859622ada3d226f90f103f659665d31/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.props#L14-L31
-
-    Disable Source Link and Xliff in WPF temp projects to avoid generating non-deterministic file names to obj dir.
-    The project name is non-deterministic and is included in the Source Link json file name and xlf directory names.
-    It's also not necessary to generate these assets.
-  -->
-  <PropertyGroup Condition="'$(IsWpfTempProject)' == 'true'">
-    <EnableSourceLink>false</EnableSourceLink>
-    <EmbedUntrackedSources>false</EmbedUntrackedSources>
-    <DeterministicSourcePaths>false</DeterministicSourcePaths>
-    <EnableXlfLocalization>false</EnableXlfLocalization>
-  </PropertyGroup>
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
   <PropertyGroup>
-    <!-- Workaround https://github.com/dotnet/wpf/issues/1718 -->
-    <EmbedUntrackedSources Condition=" '$(UseWPF)' == 'true' ">false</EmbedUntrackedSources>
+    <LangVersion Condition="'$(Language)'=='C#'">12</LangVersion>
+    <LangVersion Condition="'$(Language)'=='VB'">16.9</LangVersion>
   </PropertyGroup>
-
   <ItemGroup>
     <!-- Avoid compile error about missing namespace when combining ImplicitUsings with .NET Framework target frameworks. -->
     <Using Remove="System.Net.Http" Condition="'$(TargetFrameworkIdentifier)'=='.NETFramework'" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -24,7 +24,7 @@
     <PackageVersion Include="Microsoft.Build" Version="$(MSBuildPackageVersion)" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.6.0" />
     <PackageVersion Include="Microsoft.DotNet.PlatformAbstractions" Version="3.1.6" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageVersion Include="Microsoft.Windows.CsWin32" Version="0.2.206-beta" />
     <PackageVersion Include="Nerdbank.GitVersioning.LKG" Version="3.4.173-alpha" />
     <PackageVersion Include="Newtonsoft.Json.Schema" Version="4.0.1" />
@@ -38,17 +38,14 @@
     <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="8.0.0" />
     <PackageVersion Include="Validation" Version="2.5.51" />
     <PackageVersion Include="Xunit.Combinatorial" Version="1.6.24" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.0" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
     <PackageVersion Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageVersion Include="xunit" Version="2.8.0" />
+    <PackageVersion Include="xunit" Version="2.9.0" />
   </ItemGroup>
   <ItemGroup>
-    <GlobalPackageReference Include="CSharpIsNullAnalyzer" Version="0.1.495" />
+    <GlobalPackageReference Include="CSharpIsNullAnalyzer" Version="0.1.593" />
     <GlobalPackageReference Include="DotNetAnalyzers.DocumentationAnalyzers" Version="1.0.0-beta.59" />
     <GlobalPackageReference Include="Nullable" Version="1.3.1" />
     <GlobalPackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.556" />
-  </ItemGroup>
-  <ItemGroup>
-    <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -34,7 +34,7 @@
     <PackageVersion Include="System.Diagnostics.Tools" Version="4.3.0" />
     <PackageVersion Include="System.Memory" Version="4.5.5" />
     <PackageVersion Include="System.Runtime.Loader" Version="4.3.0" />
-    <PackageVersion Include="System.Text.Json" Version="8.0.0" />
+    <PackageVersion Include="System.Text.Json" Version="8.0.4" />
     <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="8.0.0" />
     <PackageVersion Include="Validation" Version="2.5.51" />
     <PackageVersion Include="Xunit.Combinatorial" Version="1.6.24" />

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -119,10 +119,10 @@ stages:
       clean: true
       submodules: true # keep the warnings quiet about the wiki not being enlisted
     - task: UseDotNet@2
-      displayName: Install .NET 8.0.201 SDK
+      displayName: Install .NET 8.0.300 SDK
       inputs:
         packageType: sdk
-        version: 8.0.201
+        version: 8.0.300
     - script: dotnet --info
       displayName: Show dotnet SDK info
     - bash: |

--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -23,7 +23,7 @@ jobs:
   - template: install-dependencies.yml
   - pwsh: |
       Invoke-WebRequest -Uri "https://dot.net/v1/dotnet-install.ps1" -OutFile dotnet-install.ps1
-      & .\dotnet-install.ps1 -Architecture x86 -Version 8.0.201 -InstallDir "C:\Program Files (x86)\dotnet\" -NoPath -Verbose
+      & .\dotnet-install.ps1 -Architecture x86 -Version 8.0.300 -InstallDir "C:\Program Files (x86)\dotnet\" -NoPath -Verbose
     displayName: ⚙ Install 32-bit .NET SDK and runtimes
 
   - template: dotnet.yml

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.201",
+    "version": "8.0.300",
     "rollForward": "patch",
     "allowPrerelease": false
   }

--- a/src/AssemblyInfo.vb
+++ b/src/AssemblyInfo.vb
@@ -1,0 +1,6 @@
+' Copyright (c) .NET Foundation and Contributors. All rights reserved.
+' Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+Imports System.Runtime.InteropServices
+
+<Assembly: DefaultDllImportSearchPaths(DllImportSearchPath.SafeDirectories)>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
   <ItemGroup>
-    <Compile Include="$(MSBuildThisFileDirectory)AssemblyInfo.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)AssemblyInfo.cs" Condition=" '$(Language)'=='C#' " />
+    <Compile Include="$(MSBuildThisFileDirectory)AssemblyInfo.vb" Condition=" '$(Language)'=='VB' " />
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetPathOfFileAbove($(MSBuildThisFile), $(MSBuildThisFileDirectory)..))" />

--- a/test/Nerdbank.GitVersioning.Tests/MSBuildExtensions.cs
+++ b/test/Nerdbank.GitVersioning.Tests/MSBuildExtensions.cs
@@ -25,7 +25,7 @@ internal static class MSBuildExtensions
                 if (IntPtr.Size == 4)
                 {
                     // 32-bit .NET runtime requires special code to find the x86 SDK (where MSBuild is).
-                    MSBuildLocator.RegisterMSBuildPath(@"C:\Program Files (x86)\dotnet\sdk\8.0.201");
+                    MSBuildLocator.RegisterMSBuildPath(@"C:\Program Files (x86)\dotnet\sdk\8.0.300");
                 }
                 else
                 {


### PR DESCRIPTION
- Use spaces for xml config files
- Bump .NET SDK to 8.0.300
- Merge test related dependency updates (#271)
- Bump dotnet-coverage from 17.11.0 to 17.11.3 (#272)
- Bump Nerdbank.GitVersioning to 3.6.139
- Bump nbgv to 3.6.139
- Drop SourceLink package reference
- Remove WPF workarounds for bugs fixed years ago
- Bump powershell from 7.4.2 to 7.4.3 (#275)
- Ignore .sarif files
- Add support for VB.NET projects
- Fix template expansion
- Bump several dependencies
- Fix github actions warnings
- Skip codecov publishing without token
- Enable CA2016: forward the CancellationToken
- Bump powershell from 7.4.3 to 7.4.4 (#277)
- Switch System.Text.Json to non-vulnerable version
