### PR TITLE
fix GitCommitDate being author date rather than commit date

### DIFF
--- a/src/NerdBank.GitVersioning/DisabledGit/DisabledGitContext.cs
+++ b/src/NerdBank.GitVersioning/DisabledGit/DisabledGitContext.cs
@@ -24,6 +24,8 @@ internal class DisabledGitContext : GitContext
 
     public override DateTimeOffset? GitCommitDate => null;
 
+    public override DateTimeOffset? GitCommitAuthorDate => null;
+
     public override string? HeadCanonicalName => null;
 
     public override IReadOnlyCollection<string>? HeadTags => null;

--- a/src/NerdBank.GitVersioning/GitContext.cs
+++ b/src/NerdBank.GitVersioning/GitContext.cs
@@ -114,6 +114,11 @@ public abstract class GitContext : IDisposable
     public abstract DateTimeOffset? GitCommitDate { get; }
 
     /// <summary>
+    /// Gets the date that the commit identified by <see cref="GitCommitId"/> was authored.
+    /// </summary>
+    public abstract DateTimeOffset? GitCommitAuthorDate { get; }
+
+    /// <summary>
     /// Gets the canonical name for HEAD's position (e.g. <c>refs/heads/main</c>).
     /// </summary>
     public abstract string? HeadCanonicalName { get; }

--- a/src/NerdBank.GitVersioning/LibGit2/LibGit2Context.cs
+++ b/src/NerdBank.GitVersioning/LibGit2/LibGit2Context.cs
@@ -51,7 +51,10 @@ public class LibGit2Context : GitContext
     public override bool IsHead => this.Repository.Head?.Tip?.Equals(this.Commit) ?? false;
 
     /// <inheritdoc />
-    public override DateTimeOffset? GitCommitDate => this.Commit?.Author.When;
+    public override DateTimeOffset? GitCommitDate => this.Commit?.Committer.When;
+
+    /// <inheritdoc />
+    public override DateTimeOffset? GitCommitAuthorDate => this.Commit?.Author.When;
 
     /// <inheritdoc />
     public override string HeadCanonicalName => this.Repository.Head.CanonicalName;

--- a/src/NerdBank.GitVersioning/Managed/ManagedGitContext.cs
+++ b/src/NerdBank.GitVersioning/Managed/ManagedGitContext.cs
@@ -53,7 +53,10 @@ public class ManagedGitContext : GitContext
     public override bool IsHead => this.Repository.GetHeadCommit().Equals(this.Commit);
 
     /// <inheritdoc />
-    public override DateTimeOffset? GitCommitDate => this.Commit is { } commit ? (commit.Author?.Date ?? this.Repository.GetCommit(commit.Sha, readAuthor: true).Author?.Date) : null;
+    public override DateTimeOffset? GitCommitDate => this.Commit is { } commit ? (commit.Committer?.Date ?? this.Repository.GetCommit(commit.Sha, readAuthor: true).Committer?.Date) : null;
+
+    /// <inheritdoc />
+    public override DateTimeOffset? GitCommitAuthorDate => this.Commit is { } commit ? (commit.Author?.Date ?? this.Repository.GetCommit(commit.Sha, readAuthor: true).Author?.Date) : null;
 
     /// <inheritdoc />
     public override string HeadCanonicalName => this.Repository.GetHeadAsReferenceOrSha().ToString() ?? throw new InvalidOperationException("Unable to determine the HEAD position.");

--- a/src/NerdBank.GitVersioning/ManagedGit/GitCommit.cs
+++ b/src/NerdBank.GitVersioning/ManagedGit/GitCommit.cs
@@ -48,6 +48,11 @@ public struct GitCommit : IEquatable<GitCommit>
     /// </summary>
     public GitSignature? Author { get; set; }
 
+    /// <summary>
+    /// Gets or sets the committer of this commit.
+    /// </summary>
+    public GitSignature? Committer { get; set; }
+
     public static bool operator ==(GitCommit left, GitCommit right)
     {
         return Equals(left, right);

--- a/src/NerdBank.GitVersioning/ManagedGit/GitRepository.cs
+++ b/src/NerdBank.GitVersioning/ManagedGit/GitRepository.cs
@@ -296,7 +296,7 @@ public class GitRepository : IDisposable
     /// Gets the current HEAD commit, if available.
     /// </summary>
     /// <param name="readAuthor">
-    /// A value indicating whether to populate the <see cref="GitCommit.Author"/> field.
+    /// A value indicating whether to populate the <see cref="GitCommit.Author"/> and <see cref="GitCommit.Committer"/> fields.
     /// </param>
     /// <returns>
     /// The current HEAD commit, or <see langword="null"/> if not available.
@@ -320,7 +320,7 @@ public class GitRepository : IDisposable
     /// The Git object Id of the commit.
     /// </param>
     /// <param name="readAuthor">
-    /// A value indicating whether to populate the <see cref="GitCommit.Author"/> field.
+    /// A value indicating whether to populate the <see cref="GitCommit.Author"/> and <see cref="GitCommit.Committer"/> fields.
     /// </param>
     /// <returns>
     /// The requested commit.

--- a/src/NerdBank.GitVersioning/NoGit/NoGitContext.cs
+++ b/src/NerdBank.GitVersioning/NoGit/NoGitContext.cs
@@ -30,6 +30,8 @@ internal class NoGitContext : GitContext
     /// <inheritdoc/>
     public override DateTimeOffset? GitCommitDate => null;
 
+    public override DateTimeOffset? GitCommitAuthorDate => null;
+
     /// <inheritdoc/>
     public override string? HeadCanonicalName => null;
 

--- a/src/NerdBank.GitVersioning/VersionOracle.cs
+++ b/src/NerdBank.GitVersioning/VersionOracle.cs
@@ -266,6 +266,11 @@ public class VersionOracle
     public DateTimeOffset? GitCommitDate => this.context.GitCommitDate;
 
     /// <summary>
+    /// Gets the Git revision control commit author date for HEAD (the current source code version).
+    /// </summary>
+    public DateTimeOffset? GitCommitAuthorDate => this.context.GitCommitAuthorDate;
+
+    /// <summary>
     /// Gets or sets the number of commits in the longest single path between
     /// the specified commit and the most distant ancestor (inclusive)
     /// that set the version to the value at HEAD.

--- a/src/Nerdbank.GitVersioning.Tasks/AssemblyVersionInfo.cs
+++ b/src/Nerdbank.GitVersioning.Tasks/AssemblyVersionInfo.cs
@@ -91,6 +91,8 @@ namespace Nerdbank.GitVersioning.Tasks
 
         public string GitCommitDateTicks { get; set; }
 
+        public string GitCommitAuthorDateTicks { get; set; }
+
         public bool EmitThisAssemblyClass { get; set; } = true;
 
         /// <summary>
@@ -438,6 +440,11 @@ namespace Nerdbank.GitVersioning.Tasks
             if (long.TryParse(this.GitCommitDateTicks, out long gitCommitDateTicks))
             {
                 fields.Add("GitCommitDate", (new DateTime(gitCommitDateTicks, DateTimeKind.Utc), true));
+            }
+
+            if (long.TryParse(this.GitCommitAuthorDateTicks, out long gitCommitAuthorDateTicks))
+            {
+                fields.Add("GitCommitAuthorDate", (new DateTime(gitCommitAuthorDateTicks, DateTimeKind.Utc), true));
             }
 
             if (this.AdditionalThisAssemblyFields is object)

--- a/src/Nerdbank.GitVersioning.Tasks/GetBuildVersion.cs
+++ b/src/Nerdbank.GitVersioning.Tasks/GetBuildVersion.cs
@@ -166,6 +166,13 @@ namespace Nerdbank.GitVersioning.Tasks
         public string GitCommitDateTicks { get; private set; }
 
         /// <summary>
+        /// Gets the Git revision control commit author date for HEAD (the current source code version), expressed as the number of 100-nanosecond
+        /// intervals that have elapsed since January 1, 0001 at 00:00:00.000 in the Gregorian calendar.
+        /// </summary>
+        [Output]
+        public string GitCommitAuthorDateTicks { get; private set; }
+
+        /// <summary>
         /// Gets the number of commits in the longest single path between
         /// the specified commit and the most distant ancestor (inclusive)
         /// that set the version to the value at HEAD.
@@ -266,6 +273,7 @@ namespace Nerdbank.GitVersioning.Tasks
                 this.GitCommitId = oracle.GitCommitId;
                 this.GitCommitIdShort = oracle.GitCommitIdShort;
                 this.GitCommitDateTicks = oracle.GitCommitDate is not null ? oracle.GitCommitDate.Value.UtcTicks.ToString(CultureInfo.InvariantCulture) : null;
+                this.GitCommitAuthorDateTicks = oracle.GitCommitAuthorDate is not null ? oracle.GitCommitAuthorDate.Value.UtcTicks.ToString(CultureInfo.InvariantCulture) : null;
                 this.GitVersionHeight = oracle.VersionHeight;
                 this.BuildMetadataFragment = oracle.BuildMetadataFragment;
                 this.CloudBuildNumber = oracle.CloudBuildNumberEnabled ? oracle.CloudBuildNumber : null;
@@ -314,6 +322,7 @@ namespace Nerdbank.GitVersioning.Tasks
                     { "GitCommitId", this.GitCommitId },
                     { "GitCommitIdShort", this.GitCommitIdShort },
                     { "GitCommitDateTicks", this.GitCommitDateTicks },
+                    { "GitCommitAuthorDateTicks", this.GitCommitAuthorDateTicks },
                     { "GitVersionHeight", this.GitVersionHeight.ToString(CultureInfo.InvariantCulture) },
                     { "BuildNumber", this.BuildNumber.ToString(CultureInfo.InvariantCulture) },
                     { "BuildVersionNumberComponent", this.BuildNumber.ToString(CultureInfo.InvariantCulture) },

--- a/src/Nerdbank.GitVersioning.Tasks/build/Nerdbank.GitVersioning.targets
+++ b/src/Nerdbank.GitVersioning.Tasks/build/Nerdbank.GitVersioning.targets
@@ -169,6 +169,7 @@
                   PrereleaseVersion="$(PrereleaseVersion)"
                   GitCommitId="$(GitCommitId)"
                   GitCommitDateTicks="$(GitCommitDateTicks)"
+                  GitCommitAuthorDateTicks="$(GitCommitAuthorDateTicks)"
                   EmitNonVersionCustomAttributes="$(NBGV_EmitNonVersionCustomAttributes)"
                   EmitThisAssemblyClass="$(NBGV_EmitThisAssemblyClass)"
                   AdditionalThisAssemblyFields="@(AdditionalThisAssemblyFields)"

--- a/test/Nerdbank.GitVersioning.Tests/BuildIntegrationTests.cs
+++ b/test/Nerdbank.GitVersioning.Tests/BuildIntegrationTests.cs
@@ -304,7 +304,8 @@ public abstract class BuildIntegrationTests : RepoTestBase, IClassFixture<MSBuil
         Assert.Equal(idAsVersion.Build.ToString(), buildResult.BuildVersionNumberComponent);
         Assert.Equal($"{idAsVersion.Major}.{idAsVersion.Minor}.{idAsVersion.Build}", buildResult.BuildVersionSimple);
         Assert.Equal(this.LibGit2Repository.Head.Tip.Id.Sha, buildResult.GitCommitId);
-        Assert.Equal(this.LibGit2Repository.Head.Tip.Author.When.UtcTicks.ToString(CultureInfo.InvariantCulture), buildResult.GitCommitDateTicks);
+        Assert.Equal(this.LibGit2Repository.Head.Tip.Committer.When.UtcTicks.ToString(CultureInfo.InvariantCulture), buildResult.GitCommitDateTicks);
+        Assert.Equal(this.LibGit2Repository.Head.Tip.Author.When.UtcTicks.ToString(CultureInfo.InvariantCulture), buildResult.GitCommitAuthorDateTicks);
         Assert.Equal(commitIdShort, buildResult.GitCommitIdShort);
         Assert.Equal(versionHeight.ToString(), buildResult.GitVersionHeight);
         Assert.Equal($"{version.Major}.{version.Minor}", buildResult.MajorMinorVersion);
@@ -557,6 +558,8 @@ public abstract class BuildIntegrationTests : RepoTestBase, IClassFixture<MSBuil
         public string GitCommitIdShort => this.BuildResult.ProjectStateAfterBuild.GetPropertyValue("GitCommitIdShort");
 
         public string GitCommitDateTicks => this.BuildResult.ProjectStateAfterBuild.GetPropertyValue("GitCommitDateTicks");
+
+        public string GitCommitAuthorDateTicks => this.BuildResult.ProjectStateAfterBuild.GetPropertyValue("GitCommitAuthorDateTicks");
 
         public string GitVersionHeight => this.BuildResult.ProjectStateAfterBuild.GetPropertyValue("GitVersionHeight");
 

--- a/test/Nerdbank.GitVersioning.Tests/ManagedGit/GitCommitReaderTests.cs
+++ b/test/Nerdbank.GitVersioning.Tests/ManagedGit/GitCommitReaderTests.cs
@@ -32,7 +32,11 @@ public class GitCommitReaderTests
             Assert.Equal(new DateTimeOffset(2020, 10, 6, 13, 40, 09, TimeSpan.FromHours(-6)), author.Date);
             Assert.Equal("andrewarnott@gmail.com", author.Email);
 
-            // Committer and commit message are not read
+            GitSignature committer = commit.Committer.Value;
+
+            Assert.Equal("Andrew Arnott", committer.Name);
+            Assert.Equal(new DateTimeOffset(2020, 10, 6, 14, 40, 09, TimeSpan.FromHours(-6)), committer.Date);
+            Assert.Equal("andrewarnott@gmail.com", committer.Email);
         }
     }
 

--- a/test/Nerdbank.GitVersioning.Tests/ManagedGit/commit-4497b0eaaa89abf0e6d70961ad5f04fd3a49cbc6
+++ b/test/Nerdbank.GitVersioning.Tests/ManagedGit/commit-4497b0eaaa89abf0e6d70961ad5f04fd3a49cbc6
@@ -1,6 +1,6 @@
 tree f914b48023c7c804a4f3be780d451f31aef74ac1
 parent 06cc627f28736c0d13506b0414126580fe37c6f3
 author Andrew Arnott <andrewarnott@gmail.com> 1602013209 -0600
-committer Andrew Arnott <andrewarnott@gmail.com> 1602013209 -0600
+committer Andrew Arnott <andrewarnott@gmail.com> 1602016809 -0600
 
 Set version to '3.4-alpha'

--- a/test/Nerdbank.GitVersioning.Tests/ManagedGit/commit-d56dc3ed179053abef2097d1120b4507769bcf1a
+++ b/test/Nerdbank.GitVersioning.Tests/ManagedGit/commit-d56dc3ed179053abef2097d1120b4507769bcf1a
@@ -2,6 +2,6 @@ tree f914b48023c7c804a4f3be780d451f31aef74ac1
 parent 4497b0eaaa89abf0e6d70961ad5f04fd3a49cbc6
 parent 0989e8fe0cd0e0900173b26decdfb24bc0cc8232
 author Andrew Arnott <andrewarnott@gmail.com> 1602013209 -0600
-committer Andrew Arnott <andrewarnott@gmail.com> 1602013209 -0600
+committer Andrew Arnott <andrewarnott@gmail.com> 1602016809 -0600
 
 Merge branch 'v3.3'


### PR DESCRIPTION
Fill GitCommitDate with actual value of commit date.
Add GitCommitAuthorDate property for convenience.

fixes #827 