### PR TITLE
Merge latest Library.Template

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,19 +3,19 @@
   "isRoot": true,
   "tools": {
     "powershell": {
-      "version": "7.4.4",
+      "version": "7.4.5",
       "commands": [
         "pwsh"
       ]
     },
     "dotnet-coverage": {
-      "version": "17.11.3",
+      "version": "17.12.5",
       "commands": [
         "dotnet-coverage"
       ]
     },
     "nbgv": {
-      "version": "3.6.139",
+      "version": "3.6.143",
       "commands": [
         "nbgv"
       ]

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # Refer to https://hub.docker.com/_/microsoft-dotnet-sdk for available versions
-FROM mcr.microsoft.com/dotnet/sdk:8.0.300-jammy
+FROM mcr.microsoft.com/dotnet/sdk:8.0.402-jammy
 
 # Installing mono makes `dotnet test` work without errors even for net472.
 # But installing it takes a long time, so it's excluded by default.

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -24,7 +24,7 @@
     <PackageVersion Include="Microsoft.Build" Version="$(MSBuildPackageVersion)" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.6.0" />
     <PackageVersion Include="Microsoft.DotNet.PlatformAbstractions" Version="3.1.6" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageVersion Include="Microsoft.Windows.CsWin32" Version="0.2.206-beta" />
     <PackageVersion Include="Nerdbank.GitVersioning.LKG" Version="3.4.173-alpha" />
     <PackageVersion Include="Newtonsoft.Json.Schema" Version="4.0.1" />
@@ -40,7 +40,7 @@
     <PackageVersion Include="Xunit.Combinatorial" Version="1.6.24" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
     <PackageVersion Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageVersion Include="xunit" Version="2.9.0" />
+    <PackageVersion Include="xunit" Version="2.9.2" />
   </ItemGroup>
   <ItemGroup>
     <GlobalPackageReference Include="CSharpIsNullAnalyzer" Version="0.1.593" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -34,7 +34,7 @@
     <PackageVersion Include="System.Diagnostics.Tools" Version="4.3.0" />
     <PackageVersion Include="System.Memory" Version="4.5.5" />
     <PackageVersion Include="System.Runtime.Loader" Version="4.3.0" />
-    <PackageVersion Include="System.Text.Json" Version="8.0.4" />
+    <PackageVersion Include="System.Text.Json" Version="8.0.5" />
     <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="8.0.0" />
     <PackageVersion Include="Validation" Version="2.5.51" />
     <PackageVersion Include="Xunit.Combinatorial" Version="1.6.24" />

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -119,10 +119,10 @@ stages:
       clean: true
       submodules: true # keep the warnings quiet about the wiki not being enlisted
     - task: UseDotNet@2
-      displayName: Install .NET 8.0.300 SDK
+      displayName: Install .NET 8.0.402 SDK
       inputs:
         packageType: sdk
-        version: 8.0.300
+        version: 8.0.402
     - script: dotnet --info
       displayName: Show dotnet SDK info
     - bash: |

--- a/azure-pipelines/Get-LibTemplateBasis.ps1
+++ b/azure-pipelines/Get-LibTemplateBasis.ps1
@@ -1,0 +1,25 @@
+<#
+.SYNOPSIS
+    Returns the name of the well-known branch in the Library.Template repository upon which HEAD is based.
+#>
+[CmdletBinding(SupportsShouldProcess = $true)]
+Param(
+    [switch]$ErrorIfNotRelated
+)
+
+# This list should be sorted in order of decreasing specificity.
+$branchMarkers = @(
+    @{ commit = 'fd0a7b25ccf030bbd16880cca6efe009d5b1fffc'; branch = 'microbuild' };
+    @{ commit = '05f49ce799c1f9cc696d53eea89699d80f59f833'; branch = 'main' };
+)
+
+foreach ($entry in $branchMarkers) {
+    if (git rev-list HEAD | Select-String -Pattern $entry.commit) {
+        return $entry.branch
+    }
+}
+
+if ($ErrorIfNotRelated) {
+    Write-Error "Library.Template has not been previously merged with this repo. Please review https://github.com/AArnott/Library.Template/tree/main?tab=readme-ov-file#readme for instructions."
+    exit 1
+}

--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -32,7 +32,7 @@ jobs:
 
 - job: Linux
   pool:
-    vmImage: Ubuntu 20.04
+    vmImage: Ubuntu-22.04
   steps:
   - checkout: self
     fetchDepth: 0 # avoid shallow clone so nbgv can do its work.

--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -23,7 +23,7 @@ jobs:
   - template: install-dependencies.yml
   - pwsh: |
       Invoke-WebRequest -Uri "https://dot.net/v1/dotnet-install.ps1" -OutFile dotnet-install.ps1
-      & .\dotnet-install.ps1 -Architecture x86 -Version 8.0.300 -InstallDir "C:\Program Files (x86)\dotnet\" -NoPath -Verbose
+      & .\dotnet-install.ps1 -Architecture x86 -Version 8.0.402 -InstallDir "C:\Program Files (x86)\dotnet\" -NoPath -Verbose
     displayName: ⚙ Install 32-bit .NET SDK and runtimes
 
   - template: dotnet.yml

--- a/azure-pipelines/libtemplate-update.yml
+++ b/azure-pipelines/libtemplate-update.yml
@@ -1,0 +1,146 @@
+# This pipeline schedules regular merges of Library.Template into a repo that is based on it.
+# Only Azure Repos are supported. GitHub support comes via a GitHub Actions workflow.
+
+trigger: none
+pr: none
+schedules:
+- cron: "0 3 * * Mon" # Sun @ 8 or 9 PM Mountain Time (depending on DST)
+  displayName: Weekly trigger
+  branches:
+    include:
+    - main
+  always: true
+
+parameters:
+- name: AutoComplete
+  displayName: Auto-complete pull request
+  type: boolean
+  default: false
+
+stages:
+- stage: Merge
+  jobs:
+  - job: merge
+    pool:
+      vmImage: ubuntu-latest
+    steps:
+    - checkout: self
+      fetchDepth: 0
+      clean: true
+    - pwsh: |
+        $LibTemplateBranch = & ./azure-pipelines/Get-LibTemplateBasis.ps1 -ErrorIfNotRelated
+        if ($LASTEXITCODE -ne 0) {
+          exit $LASTEXITCODE
+        }
+
+        git fetch https://github.com/aarnott/Library.Template $LibTemplateBranch
+        if ($LASTEXITCODE -ne 0) {
+          exit $LASTEXITCODE
+        }
+        $LibTemplateCommit = git rev-parse FETCH_HEAD
+
+        if ((git rev-list FETCH_HEAD ^HEAD --count) -eq 0) {
+          Write-Host "There are no Library.Template updates to merge."
+          exit 0
+        }
+
+        $UpdateBranchName = 'auto/libtemplateUpdate'
+        git -c http.extraheader="AUTHORIZATION: bearer $(System.AccessToken)" push origin -f FETCH_HEAD:refs/heads/$UpdateBranchName
+
+        Write-Host "Creating pull request"
+        $contentType = 'application/json';
+        $headers = @{ Authorization = 'Bearer $(System.AccessToken)' };
+        $rawRequest = @{
+          sourceRefName = "refs/heads/$UpdateBranchName";
+          targetRefName = "refs/heads/main";
+          title = 'Merge latest Library.Template';
+          description = "This merges the latest features and fixes from [Library.Template's $LibTemplateBranch branch](https://github.com/AArnott/Library.Template/tree/$LibTemplateBranch).";
+        }
+        $request = ConvertTo-Json $rawRequest
+
+        $prApiBaseUri = '$(System.TeamFoundationCollectionUri)/$(System.TeamProject)/_apis/git/repositories/$(Build.Repository.ID)/pullrequests'
+        $prCreationUri = $prApiBaseUri + "?api-version=6.0"
+        Write-Host "POST $prCreationUri"
+        Write-Host $request
+
+        $prCreationResult = Invoke-RestMethod -uri $prCreationUri -method POST -Headers $headers -ContentType $contentType -Body $request
+        $prUrl = "$($prCreationResult.repository.webUrl)/pullrequest/$($prCreationResult.pullRequestId)"
+        Write-Host "Pull request: $prUrl"
+        $prApiBaseUri += "/$($prCreationResult.pullRequestId)"
+
+        $SummaryPath = Join-Path '$(Agent.TempDirectory)' 'summary.md'
+        Set-Content -Path $SummaryPath -Value "[Insertion pull request]($prUrl)"
+        Write-Host "##vso[task.uploadsummary]$SummaryPath"
+
+        # Tag the PR
+        $tagUri = "$prApiBaseUri/labels?api-version=7.0"
+        $rawRequest = @{
+          name = 'auto-template-merge';
+        }
+        $request = ConvertTo-Json $rawRequest
+        Invoke-RestMethod -uri $tagUri -method POST -Headers $headers -ContentType $contentType -Body $request | Out-Null
+
+        # Add properties to the PR that we can programatically parse later.
+        Function Set-PRProperties($properties) {
+          $rawRequest = $properties.GetEnumerator() |% {
+            @{
+              op = 'add'
+              path = "/$($_.key)"
+              from = $null
+              value = $_.value
+            }
+          }
+          $request = ConvertTo-Json $rawRequest
+          $setPrPropertyUri = "$prApiBaseUri/properties?api-version=7.0"
+          Write-Debug "$request"
+          $setPrPropertyResult = Invoke-RestMethod -uri $setPrPropertyUri -method PATCH -Headers $headers -ContentType 'application/json-patch+json' -Body $request -StatusCodeVariable setPrPropertyStatus -SkipHttpErrorCheck
+          if ($setPrPropertyStatus -ne 200) {
+            Write-Host "##vso[task.logissue type=warning]Failed to set pull request properties. Result: $setPrPropertyStatus. $($setPrPropertyResult.message)"
+          }
+        }
+        Write-Host "Setting pull request properties"
+        Set-PRProperties @{
+          'AutomatedMerge.SourceBranch' = $LibTemplateBranch
+          'AutomatedMerge.SourceCommit' = $LibTemplateCommit
+        }
+
+        # Add an *active* PR comment to warn users to *merge* the pull request instead of squash it.
+        $request = ConvertTo-Json @{
+          comments = @(
+            @{
+              parentCommentId = 0
+              content = "Do **not** squash this pull request when completing it. You must *merge* it."
+              commentType = 'system'
+            }
+          )
+          status = 'active'
+        }
+        $result = Invoke-RestMethod -uri "$prApiBaseUri/threads?api-version=7.1" -method POST -Headers $headers -ContentType $contentType -Body $request -StatusCodeVariable addCommentStatus -SkipHttpErrorCheck
+        if ($addCommentStatus -ne 200) {
+          Write-Host "##vso[task.logissue type=warning]Failed to post comment on pull request. Result: $addCommentStatus. $($result.message)"
+        }
+
+        # Set auto-complete on the PR
+        if ('${{ parameters.AutoComplete }}' -eq 'True') {
+          Write-Host "Setting auto-complete"
+          $mergeMessage = "Merged PR $($prCreationResult.pullRequestId): " + $commitMessage
+          $rawRequest = @{
+            autoCompleteSetBy = @{
+              id = $prCreationResult.createdBy.id
+            };
+            completionOptions = @{
+              deleteSourceBranch = $true;
+              mergeCommitMessage = $mergeMessage;
+              mergeStrategy = 'noFastForward';
+            };
+          }
+          $request = ConvertTo-Json $rawRequest
+          Write-Host $request
+          $uri = "$($prApiBaseUri)?api-version=6.0"
+          $result = Invoke-RestMethod -uri $uri -method PATCH -Headers $headers -ContentType $contentType -Body $request -StatusCodeVariable autoCompleteStatus -SkipHttpErrorCheck
+          if ($autoCompleteStatus -ne 200) {
+            Write-Host "##vso[task.logissue type=warning]Failed to set auto-complete on pull request. Result: $autoCompleteStatus. $($result.message)"
+          }
+        }
+
+      displayName: Create pull request

--- a/azure-pipelines/publish-codecoverage.yml
+++ b/azure-pipelines/publish-codecoverage.yml
@@ -9,9 +9,8 @@ steps:
   continueOnError: true
 - powershell: azure-pipelines/Merge-CodeCoverage.ps1 -Path '$(Pipeline.Workspace)' -OutputFile coveragereport/merged.cobertura.xml -Format Cobertura -Verbose
   displayName: ⚙ Merge coverage
-- task: PublishCodeCoverageResults@1
+- task: PublishCodeCoverageResults@2
   displayName: 📢 Publish code coverage results to Azure DevOps
   inputs:
-    codeCoverageTool: cobertura
     summaryFileLocation: coveragereport/merged.cobertura.xml
     failIfCoverageEmpty: true

--- a/azurepipelines-coverage.yml
+++ b/azurepipelines-coverage.yml
@@ -1,0 +1,6 @@
+# https://learn.microsoft.com/azure/devops/pipelines/test/codecoverage-for-pullrequests?view=azure-devops
+coverage:
+  status:
+    comments: on    # add comment to PRs reporting diff in coverage of modified files
+    diff:           # diff coverage is code coverage only for the lines changed in a pull request.
+      target: 70%   # set this to a desired %. Default is 70%

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.300",
+    "version": "8.0.402",
     "rollForward": "patch",
     "allowPrerelease": false
   }

--- a/test/Nerdbank.GitVersioning.Tests/MSBuildExtensions.cs
+++ b/test/Nerdbank.GitVersioning.Tests/MSBuildExtensions.cs
@@ -25,7 +25,7 @@ internal static class MSBuildExtensions
                 if (IntPtr.Size == 4)
                 {
                     // 32-bit .NET runtime requires special code to find the x86 SDK (where MSBuild is).
-                    MSBuildLocator.RegisterMSBuildPath(@"C:\Program Files (x86)\dotnet\sdk\8.0.300");
+                    MSBuildLocator.RegisterMSBuildPath(@"C:\Program Files (x86)\dotnet\sdk\8.0.402");
                 }
                 else
                 {

--- a/tools/MergeFrom-Template.ps1
+++ b/tools/MergeFrom-Template.ps1
@@ -1,0 +1,79 @@
+
+<#
+.SYNOPSIS
+    Merges the latest changes from Library.Template into HEAD of this repo.
+.PARAMETER LocalBranch
+    The name of the local branch to create at HEAD and use to merge into from Library.Template.
+#>
+[CmdletBinding(SupportsShouldProcess = $true)]
+Param(
+    [string]$LocalBranch = "dev/$($env:USERNAME)/libtemplateUpdate"
+)
+
+Function Spawn-Tool($command, $commandArgs, $workingDirectory, $allowFailures) {
+    if ($workingDirectory) {
+        Push-Location $workingDirectory
+    }
+    try {
+        if ($env:TF_BUILD) {
+            Write-Host "$pwd >"
+            Write-Host "##[command]$command $commandArgs"
+        }
+        else {
+            Write-Host "$command $commandArgs" -ForegroundColor Yellow
+        }
+        if ($commandArgs) {
+            & $command @commandArgs
+        } else {
+            Invoke-Expression $command
+        }
+        if ((!$allowFailures) -and ($LASTEXITCODE -ne 0)) { exit $LASTEXITCODE }
+    }
+    finally {
+        if ($workingDirectory) {
+            Pop-Location
+        }
+    }
+}
+
+$remoteBranch = & $PSScriptRoot\..\azure-pipelines\Get-LibTemplateBasis.ps1 -ErrorIfNotRelated
+if ($LASTEXITCODE -ne 0) {
+    exit $LASTEXITCODE
+}
+
+$LibTemplateUrl = 'https://github.com/aarnott/Library.Template'
+Spawn-Tool 'git' ('fetch', $LibTemplateUrl, $remoteBranch)
+$SourceCommit = git rev-parse FETCH_HEAD
+$BaseBranch = Spawn-Tool 'git' ('branch', '--show-current')
+$SourceCommitUrl = "$LibTemplateUrl/commit/$SourceCommit"
+
+# To reduce the odds of merge conflicts at this stage, we always move HEAD to the last successful merge.
+$basis = Spawn-Tool 'git' ('rev-parse', 'HEAD') # TODO: consider improving this later
+
+Write-Host "Merging the $remoteBranch branch of Library.Template ($SourceCommit) into local repo $basis" -ForegroundColor Green
+
+Spawn-Tool 'git' ('checkout', '-b', $LocalBranch, $basis) $null $true
+if ($LASTEXITCODE -eq 128) {
+    Spawn-Tool 'git' ('checkout', $LocalBranch)
+    Spawn-Tool 'git' ('merge', $basis)
+}
+
+Spawn-Tool 'git' ('merge', 'FETCH_HEAD', '--no-ff', '-m', "Merge the $remoteBranch branch from $LibTemplateUrl`n`nSpecifically, this merges [$SourceCommit from that repo]($SourceCommitUrl).")
+if ($LASTEXITCODE -eq 1) {
+    Write-Error "Merge conflict detected. Manual resolution required."
+    exit 1
+}
+elseif ($LASTEXITCODE -ne 0) {
+    Write-Error "Merge failed with exit code $LASTEXITCODE."
+    exit $LASTEXITCODE
+}
+
+$result = New-Object PSObject -Property @{
+    BaseBranch   = $BaseBranch   # The original branch that was checked out when the script ran.
+    LocalBranch  = $LocalBranch  # The name of the local branch that was created before the merge.
+    SourceCommit = $SourceCommit # The commit from Library.Template that was merged in.
+    SourceBranch = $remoteBranch # The branch from Library.Template that was merged in.
+}
+
+Write-Host $result
+Write-Output $result


### PR DESCRIPTION
- **Update PublishCodeCoverageResults task to v2**
- **Bump Nerdbank.GitVersioning from 3.6.139 to 3.6.141 (#280)**
- **Bump nbgv from 3.6.139 to 3.6.141 (#279)**
- **Bump dotnet-coverage from 17.11.3 to 17.11.5 (#278)**
- **Bump .NET SDK to 8.0.400**
- **Post code coverage diff comments for AzDO PRs**
- **Bump Microsoft.NET.Test.Sdk to 17.11**
- **Bump powershell from 7.4.4 to 7.4.5 (#282)**
- **Bump Nerdbank.GitVersioning from 3.6.141 to 3.6.143 (#283)**
- **Bump nbgv from 3.6.141 to 3.6.143 (#284)**
- **Bump dotnet-coverage from 17.11.5 to 17.12.2 (#285)**
- **Bump dotnet-coverage from 17.12.2 to 17.12.3 (#288)**
- **Bump Microsoft.NET.Test.Sdk from 17.11.0 to 17.11.1 (#287)**
- **Bump dotnet-coverage from 17.12.3 to 17.12.4 (#289)**
- **Bump xunit from 2.9.0 to 2.9.1 (#290)**
- **Bump dotnet-coverage from 17.12.4 to 17.12.5 (#292)**
- **Bump xunit from 2.9.1 to 2.9.2 (#291)**
- **Build on ubuntu 22 in cloud builds**
- **Add AzDO pipeline to help keep repos up-to-date**
- **Bump .NET SDK to 8.0.402**
- **Fix linux agent on AzDO**
- **Update build agent to macos-14**
