### PR TITLE
Ensure GetBuildVersion runs before Clean

### DIFF
--- a/src/Nerdbank.GitVersioning.Tasks/build/Nerdbank.GitVersioning.targets
+++ b/src/Nerdbank.GitVersioning.Tasks/build/Nerdbank.GitVersioning.targets
@@ -8,6 +8,11 @@
       $(VersionDependsOn)
     </VersionDependsOn>
 
+    <CleanDependsOn>
+      GetBuildVersion;
+      $(CleanDependsOn)
+    </CleanDependsOn>
+
     <GenerateNuspecDependsOn>
       GetBuildVersion;
       $(GenerateNuspecDependsOn)

--- a/test/Nerdbank.GitVersioning.Tests/BuildIntegrationTests.cs
+++ b/test/Nerdbank.GitVersioning.Tests/BuildIntegrationTests.cs
@@ -132,6 +132,14 @@ public abstract class BuildIntegrationTests : RepoTestBase, IClassFixture<MSBuil
     }
 
     [Fact]
+    public async Task GetBuildVersion_Hooks_Clean()
+    {
+        this.WriteVersionFile("1.2");
+        BuildResults buildResult = await this.BuildAsync("Clean");
+        Assert.Equal("1.2", buildResult.BuildVersion);
+    }
+
+    [Fact]
     public async Task GetBuildVersion_Without_Git_HighPrecisionAssemblyVersion()
     {
         this.WriteVersionFile(new VersionOptions


### PR DESCRIPTION
Fixes #1067 

This change hooks `GetBuildVersion` into the `Clean` target. This is important for scenarios where the build version is part of an output's name, such as when using `<GeneratePackageOnBuild>`. Otherwise, the build version isn't set and the default version (e.g. 1.0.0) is used, resulting in an incomplete clean.