### PR TITLE
Add dotnet sdk configuration for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,11 @@ updates:
   directory: /src/nerdbank-gitversioning.npm
   schedule:
     interval: monthly
+- package-ecosystem: dotnet-sdk
+  directory: /
+  schedule:
+    interval: monthly
+  ignore:
+    - dependency-name: "*"
+      update-types:
+        - version-update:semver-major


### PR DESCRIPTION
This configuration will allow dependabot to create patch PRs for the .NET SDK. See https://github.blog/changelog/2024-11-19-dependabot-can-now-perform-version-updates-for-the-net-sdk/