### PR TITLE
Introduce `NBGV_UseAssemblyVersionInNativeVersion` msbuild property

### DIFF
--- a/doc/msbuild.md
+++ b/doc/msbuild.md
@@ -49,6 +49,7 @@ Property | Default | Description
 `NBGV_ThisAssemblyNamespace` | (empty) | Sets the namespace to use for the generated `ThisAssembly` class.
 `NBGV_EmitThisAssemblyClass` | `true` | When `false`, suppresses generation of the `ThisAssembly` class.
 `NBGV_ThisAssemblyIncludesPackageVersion` | `false` | When `true`, a `NuGetPackageVersion` property is added to the `ThisAssembly` class.
+`NBGV_UseAssemblyVersionInNativeVersion` | `true` | When `false`, uses the `AssemblyFileVersion` as a native `PRODUCTVERSION`.
 
 ### Custom `ThisAssembly` static fields and constants
 

--- a/src/Nerdbank.GitVersioning.Tasks/NativeVersionInfo.cs
+++ b/src/Nerdbank.GitVersioning.Tasks/NativeVersionInfo.cs
@@ -108,6 +108,8 @@ END
 
         public string TargetFileName { get; set; }
 
+        public bool UseAssemblyVersionInNativeVersion { get; set; } = true;
+
         /// <inheritdoc/>
         public override bool Execute()
         {
@@ -166,7 +168,7 @@ END
                 return;
             }
 
-            if (!Version.TryParse(this.AssemblyVersion, out Version productVersion))
+            if (!Version.TryParse(this.AssemblyVersion, out Version productVersion) || !this.UseAssemblyVersionInNativeVersion)
             {
                 productVersion = fileVersion;
             }

--- a/src/Nerdbank.GitVersioning.Tasks/build/Nerdbank.GitVersioning.targets
+++ b/src/Nerdbank.GitVersioning.Tasks/build/Nerdbank.GitVersioning.targets
@@ -215,6 +215,7 @@
                   AssemblyLanguage="$(AssemblyLanguage)"
                   AssemblyCodepage="$(AssemblyCodepage)"
                   TargetFileName="$(TargetFileName)"
+                  UseAssemblyVersionInNativeVersion="$(NBGV_UseAssemblyVersionInNativeVersion)"
                   />
     <!-- Avoid applying the newly generated Version.rc file to the build
          unless it has changed in order to allow for incremental building. -->


### PR DESCRIPTION
The new `NBGV_UseAssemblyVersionInNativeVersion` switch allows user to choose whether `AssemblyVersion` (default) or `AssemblyFileVersion` is used as a source for [`PRODUCTVERSION`](https://learn.microsoft.com/en-us/windows/win32/menurc/versioninfo-resource#parameters)

https://github.com/dotnet/Nerdbank.GitVersioning/blob/88f4c2d70905ac5980759daed5392279d263b59a/src/Nerdbank.GitVersioning.Tasks/NativeVersionInfo.cs#L42-L45