### PR TITLE
Stop dependabot from updating the SDK

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,10 +7,6 @@ updates:
   directory: /
   schedule:
     interval: monthly
-- package-ecosystem: dotnet-sdk
-  directory: /
-  schedule:
-    interval: monthly
 - package-ecosystem: npm
   directory: /src/nerdbank-gitversioning.npm
   schedule:


### PR DESCRIPTION
It'll always fail from dependabot because other changes are _always_ required.
