### PR TITLE
Migrate to xunit v3

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -12,3 +12,7 @@ FROM mcr.microsoft.com/dotnet/sdk:10.0.302@sha256:72dd743782f2ae7e5476fd64f6a460
 # See https://github.com/dotnet/dotnet-docker/issues/2790 for a discussion on this, where the prioritized use case
 # was *not* devcontainers, sadly.
 ENV NUGET_XMLDOC_MODE=
+
+# Install the same Node.js major version used in CI.
+RUN curl -fsSL https://deb.nodesource.com/setup_24.x | bash -
+RUN apt-get install -y nodejs

--- a/tools/dotnet-test-cloud.ps1
+++ b/tools/dotnet-test-cloud.ps1
@@ -40,6 +40,10 @@ if ($x86) {
     $dotnet32Matches = $dotnet32Possibilities |? { Test-Path $_ }
     if ($dotnet32Matches) {
       $dotnet = Resolve-Path @($dotnet32Matches)[0]
+      $dotnetRoot = Split-Path $dotnet
+      $env:DOTNET_ROOT_X86 = $dotnetRoot
+      $env:DOTNET_HOST_PATH = $dotnet
+      $env:PATH = "$dotnetRoot$([IO.Path]::PathSeparator)$env:PATH"
       Write-Host "Running tests using `"$dotnet`"" -ForegroundColor DarkGray
     } else {
       Write-Error "Unable to find 32-bit dotnet.exe"
@@ -96,15 +100,31 @@ if ($isMTP) {
        $mtpArgs += '--report-trx'
     }
 
-    & $dotnet test --solution $RepoRoot `
-       --no-build `
-        -c $Configuration `
-        -bl:"$testBinLog" `
-        --filter-not-trait 'TestCategory=FailsInCloudTest' `
-        @mtpArgs `
-        @dumpSwitches `
-        @extraArgs
-    if ($LASTEXITCODE -ne 0) { $failedTests += 1 }
+    if ($x86) {
+        # MTP test projects are executables, so each one must be built for x86 before it can run as an x86 process.
+        Get-ChildItem -Path "$RepoRoot\test" -Filter *.Tests.csproj -Recurse |% {
+            $projectBinLog = Join-Path $ArtifactStagingFolder (Join-Path build_logs "$($_.BaseName).x86.binlog")
+            & $dotnet test --project $_.FullName `
+                --arch x86 `
+                -c $Configuration `
+                -bl:"$projectBinLog" `
+                --filter-not-trait 'TestCategory=FailsInCloudTest' `
+                @mtpArgs `
+                @dumpSwitches `
+                @extraArgs
+            if ($LASTEXITCODE -ne 0) { $failedTests += 1 }
+        }
+    } else {
+        & $dotnet test --solution $RepoRoot `
+            --no-build `
+            -c $Configuration `
+            -bl:"$testBinLog" `
+            --filter-not-trait 'TestCategory=FailsInCloudTest' `
+            @mtpArgs `
+            @dumpSwitches `
+            @extraArgs
+        if ($LASTEXITCODE -ne 0) { $failedTests += 1 }
+    }
 
     $trxFiles = @(Get-ChildItem -Recurse -Path $testLogs\*.trx -ErrorAction Ignore)
 } else {


### PR DESCRIPTION
- [x] Fix and verify that all tests run on both agents.

Validation:
- Release build and package creation succeeds with warnings treated as errors.
- Windows x64 MTP run discovers 2,561 tests.
- Windows x86 MTP run now builds and executes genuine x86 test hosts and discovers the same 2,561 tests.
- Both local runs reached all tests; three native-resource tests require the VS 2019 `v142` C++ toolset that is not installed on the validation machine and remain covered by CI.