### PR TITLE
Don't try to disable CA2243 warnings in the generated version info files for F#

### DIFF
--- a/src/Nerdbank.GitVersioning.Tasks/AssemblyVersionInfo.cs
+++ b/src/Nerdbank.GitVersioning.Tasks/AssemblyVersionInfo.cs
@@ -709,9 +709,14 @@ namespace Nerdbank.GitVersioning.Tasks
             {
             }
 
+            protected override IEnumerable<string> WarningCodesToSuppress { get; } = [];
+
             internal override void AddAnalysisSuppressions()
             {
-                this.CodeBuilder.AppendLine($"#nowarn {string.Join(" ", this.WarningCodesToSuppress.Select(c => $"\"{c}\""))}");
+                if (this.WarningCodesToSuppress.Any())
+                {
+                    this.CodeBuilder.AppendLine($"#nowarn {string.Join(" ", this.WarningCodesToSuppress.Select(c => $"\"{c}\""))}");
+                }
             }
 
             internal override void AddComment(string comment)

--- a/test/Nerdbank.GitVersioning.Tests/AssemblyInfoTest.cs
+++ b/test/Nerdbank.GitVersioning.Tests/AssemblyInfoTest.cs
@@ -61,7 +61,6 @@ public class AssemblyInfoTest : IClassFixture<MSBuildFixture> // The MSBuildFixt
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-#nowarn ""CA2243""
 
 namespace AssemblyInfo
 [<assembly: global.System.Reflection.AssemblyVersionAttribute(""1.3.0.0"")>]
@@ -121,7 +120,6 @@ do()
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-#nowarn ""CA2243""
 
 namespace {(
     !string.IsNullOrWhiteSpace(thisAssemblyNamespace)


### PR DESCRIPTION
refs #1173

Maybe it'd be easier to just make AddAnalysisSuppressions() a no-op for F# for now, but I thought maybe overriding WarningCodesToSuppress to an empty collection and then handling that case would be more flexible in case it actually does need to supress any other warnings later.