### PR TITLE
Add option to set / skip CloudBuildNumber

### DIFF
--- a/src/Cake.GitVersioning/GitVersioningAliases.cs
+++ b/src/Cake.GitVersioning/GitVersioningAliases.cs
@@ -87,6 +87,7 @@ namespace Cake.GitVersioning
                 settings.CISystem?.ToString(),
                 settings.AllVariables,
                 settings.CommonVariables,
+                settings.CloudBuildNumber,
                 settings.AdditionalVariables,
                 false);
         }

--- a/src/Cake.GitVersioning/GitVersioningCloudSettings.cs
+++ b/src/Cake.GitVersioning/GitVersioningCloudSettings.cs
@@ -29,20 +29,20 @@ namespace Cake.GitVersioning
 
         /// <summary>
         /// Gets or sets a value indicating whether to define ALL version variables as cloud build variables, with a "NBGV_" prefix.
-        /// Default value: <see langword="false" />.
         /// </summary>
-        public bool AllVariables { get; set; } = false;
+        /// <value>The default value is <see langword="false" />.</value>
+        public bool AllVariables { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether to define a few common version variables as cloud build variables, with a "Git" prefix.
-        /// Default value: <see langword="false" />.
         /// </summary>
-        public bool CommonVariables { get; set; } = false;
+        /// <value>The default value is <see langword="false" />.</value>
+        public bool CommonVariables { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether to set the cloud build number.
-        /// Default value: <see langword="true" />.
         /// </summary>
+        /// <value>The default value is <see langword="true" />.</value>
         public bool CloudBuildNumber { get; set; } = true;
 
         /// <summary>

--- a/src/Cake.GitVersioning/GitVersioningCloudSettings.cs
+++ b/src/Cake.GitVersioning/GitVersioningCloudSettings.cs
@@ -29,18 +29,21 @@ namespace Cake.GitVersioning
 
         /// <summary>
         /// Gets or sets a value indicating whether to define ALL version variables as cloud build variables, with a "NBGV_" prefix.
+        /// Default value: <see langword="false" />.
         /// </summary>
-        public bool AllVariables { get; set; }
+        public bool AllVariables { get; set; } = false;
 
         /// <summary>
         /// Gets or sets a value indicating whether to define a few common version variables as cloud build variables, with a "Git" prefix.
+        /// Default value: <see langword="false" />.
         /// </summary>
-        public bool CommonVariables { get; set; }
+        public bool CommonVariables { get; set; } = false;
 
         /// <summary>
         /// Gets or sets a value indicating whether to set the cloud build number.
+        /// Default value: <see langword="true" />.
         /// </summary>
-        public bool CloudBuildNumber { get; set; }
+        public bool CloudBuildNumber { get; set; } = true;
 
         /// <summary>
         /// Gets additional cloud build variables to define.

--- a/src/Cake.GitVersioning/GitVersioningCloudSettings.cs
+++ b/src/Cake.GitVersioning/GitVersioningCloudSettings.cs
@@ -38,6 +38,11 @@ namespace Cake.GitVersioning
         public bool CommonVariables { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether to set the cloud build number.
+        /// </summary>
+        public bool CloudBuildNumber { get; set; }
+
+        /// <summary>
         /// Gets additional cloud build variables to define.
         /// </summary>
         public Dictionary<string, string> AdditionalVariables { get; } = new(StringComparer.OrdinalIgnoreCase);

--- a/src/NerdBank.GitVersioning/Commands/CloudCommand.cs
+++ b/src/NerdBank.GitVersioning/Commands/CloudCommand.cs
@@ -69,13 +69,16 @@ public class CloudCommand
     /// <param name="commonVars">
     /// Controls whether to define common version variables as cloud build variables.
     /// </param>
+    /// <param name="cloudBuildNumber">
+    /// Controls whether to emit the cloud build variable to set the build number.
+    /// </param>
     /// <param name="additionalVariables">
     /// Additional cloud build variables to define.
     /// </param>
     /// <param name="alwaysUseLibGit2">
     /// Force usage of LibGit2 for accessing the git repository.
     /// </param>
-    public void SetBuildVariables(string projectDirectory, IEnumerable<string> metadata, string version, string ciSystem, bool allVars, bool commonVars, IEnumerable<KeyValuePair<string, string>> additionalVariables, bool alwaysUseLibGit2)
+    public void SetBuildVariables(string projectDirectory, IEnumerable<string> metadata, string version, string ciSystem, bool allVars, bool commonVars, bool cloudBuildNumber, IEnumerable<KeyValuePair<string, string>> additionalVariables, bool alwaysUseLibGit2)
     {
         Requires.NotNull(projectDirectory, nameof(projectDirectory));
         Requires.NotNull(additionalVariables, nameof(additionalVariables));
@@ -137,7 +140,10 @@ public class CloudCommand
                 version = oracle.CloudBuildNumber;
             }
 
-            activeCloudBuild.SetCloudBuildNumber(version, this.stdout, this.stderr);
+            if (cloudBuildNumber)
+            {
+                activeCloudBuild.SetCloudBuildNumber(version, this.stdout, this.stderr);
+            }
 
             foreach (KeyValuePair<string, string> pair in variables)
             {

--- a/src/nbgv/Program.cs
+++ b/src/nbgv/Program.cs
@@ -194,7 +194,7 @@ namespace Nerdbank.GitVersioning.Tool
                 var ciSystem = new Option<string>(new[] { "--ci-system", "-s" }, "Force activation for a particular CI system. If not specified, auto-detection will be used. Supported values are: " + string.Join(", ", CloudProviderNames)).FromAmong(CloudProviderNames);
                 var allVars = new Option<bool>(new[] { "--all-vars", "-a" }, "Defines ALL version variables as cloud build variables, with a \"NBGV_\" prefix.");
                 var commonVars = new Option<bool>(new[] { "--common-vars", "-c" }, "Defines a few common version variables as cloud build variables, with a \"Git\" prefix (e.g. GitBuildVersion, GitBuildVersionSimple, GitAssemblyInformationalVersion).");
-                var skipCloudBuildNumber = new Option<bool>(new[] { "--skip-cloud-build-number", "-b" }, "Do not emit the cloud build variable to set the build number. This is useful when you want to set other cloud build variables but not the build number.");
+                var skipCloudBuildNumber = new Option<bool>(new[] { "--skip-cloud-build-number" }, "Do not emit the cloud build variable to set the build number. This is useful when you want to set other cloud build variables but not the build number.");
                 var define = new Option<string[]>(new[] { "--define", "-d" }, () => Array.Empty<string>(), "Additional cloud build variables to define. Each should be in the NAME=VALUE syntax.")
                 {
                     Arity = ArgumentArity.OneOrMore,

--- a/test/Nerdbank.GitVersioning.Tests/CommandTests.cs
+++ b/test/Nerdbank.GitVersioning.Tests/CommandTests.cs
@@ -12,10 +12,12 @@ public class CommandTests : RepoTestBase
     {
     }
 
-    // TODO: This is tightly coupled to the cloud build service. Can I use a FakeCloudBuildService instead?
     [Theory, CombinatorialData]
-    public void CloudCommand_CloudBuildNumber([CombinatorialValues("VisualStudioTeamServices", "TeamCity", "Jenkins")] string ciSystem, bool setCloudBuildNumber)
+    public void CloudCommand_CloudBuildNumber(bool setCloudBuildNumber)
     {
+        const string ciSystem = "VisualStudioTeamServices";
+        const string buildNumberSyntax = "##vso[build.updatebuildnumber]";
+
         var outWriter = new StringWriter();
         var errWriter = new StringWriter();
 
@@ -28,11 +30,11 @@ public class CommandTests : RepoTestBase
 
         if (setCloudBuildNumber)
         {
-            Assert.NotEmpty(outWriter.ToString());
+            Assert.Contains(buildNumberSyntax, outWriter.ToString());
         }
         else
         {
-            Assert.Empty(outWriter.ToString());
+            Assert.DoesNotContain(buildNumberSyntax, outWriter.ToString());
         }
 
         Assert.Empty(errWriter.ToString());

--- a/test/Nerdbank.GitVersioning.Tests/CommandTests.cs
+++ b/test/Nerdbank.GitVersioning.Tests/CommandTests.cs
@@ -1,0 +1,40 @@
+// Copyright (c) .NET Foundation and Contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Nerdbank.GitVersioning;
+using Nerdbank.GitVersioning.Commands;
+using Xunit;
+
+public class CommandTests : RepoTestBase
+{
+    private readonly TestOutputHelperToTextWriterAdapter adapter;
+
+    public CommandTests(ITestOutputHelper logger)
+        : base(logger)
+    {
+        this.adapter = new(logger);
+    }
+
+    // TODO: This is tightly coupled to the cloud build service. Can I use a FakeCloudBuildService instead?
+    [Theory]
+    [InlineData("VisualStudioTeamServices")]
+    [InlineData("TeamCity")]
+    [InlineData("Jenkins")]
+    public void CloudCommand_BuildNumber(string ciSystem)
+    {
+        var outWriter = new StringWriter();
+        var errWriter = new StringWriter();
+
+        var command = new CloudCommand(outWriter, errWriter);
+
+        command.SetBuildVariables(this.RepoPath, metadata: [], version: "1.2.3.4", ciSystem, allVars: false, commonVars: false, additionalVariables: [], alwaysUseLibGit2: false);
+
+        outWriter.Flush();
+        errWriter.Flush();
+        Assert.NotEmpty(outWriter.ToString());
+        Assert.Empty(errWriter.ToString());
+    }
+
+    protected override GitContext CreateGitContext(string path, string committish = null)
+        => GitContext.Create(path, committish, engine: GitContext.Engine.ReadWrite);
+}


### PR DESCRIPTION
Fixes #1189 

This PR adds the ability to set / skip the CloudBuildNumber in both the Cake task and the CLI.

## Common
- Adds a new bool `cloudBuildNumber` to `CloudCommand::SetBuildVariables`
 
## Cake.GitVersioning

- Adds a new `CloudBuildNumber` to `GetVersioningCloudSettings` with the default value of `true`
- Makes the default values of `AllVariables` and `CommonVariables` explicit (but no change)

## nbgv CLI

- Adds a new command line switch `--skip-cloud-build-number` / `-b` which if specified sets `cloudBuildNumber` to `false`.

## Tests

- There weren't any automated tests to cover this scenario, so added some basic tests