### PR TITLE
Catch a more general JsonException.

### DIFF
--- a/src/NerdBank.GitVersioning/VersionFile.cs
+++ b/src/NerdBank.GitVersioning/VersionFile.cs
@@ -123,7 +123,7 @@ public abstract class VersionFile
     }
 
     /// <summary>
-    /// Tries to read a version.json file from the specified string, but favors returning null instead of throwing a <see cref="JsonSerializationException"/>.
+    /// Tries to read a version.json file from the specified string, but favors returning null instead of throwing a <see cref="JsonException"/>.
     /// </summary>
     /// <param name="jsonContent">The content of the version.json file.</param>
     /// <param name="repoRelativeBaseDirectory">Directory that this version.json file is relative to the root of the repository.</param>
@@ -134,7 +134,7 @@ public abstract class VersionFile
         {
             return JsonConvert.DeserializeObject<VersionOptions>(jsonContent, VersionOptions.GetJsonSettings(repoRelativeBaseDirectory: repoRelativeBaseDirectory));
         }
-        catch (JsonSerializationException)
+        catch (JsonException)
         {
             return null;
         }


### PR DESCRIPTION
Catch a more general `JsonException` (instead of `JsonSerializationException`) in `FileVersion.TryReadVersionJsonContent()`.

---

A missing comma in `version.json` (see example below) results in `JsonException` thrown by `JsonConvert.DeserializeObject()`.
`JsonException` exception is more general than `JsonSerializationException` expected by `VersionFile.TryReadVersionJsonContent()` try/catch block and ultimately results in failure of `Nerdbank.GitVersioning.Tasks.GetBuildVersion`.

Catching a more general JSON exception seems to be in line with the spirit of `VersionFile.TryReadVersionJsonContent()`.

Example `version.json` to reproduce problem:
```
{
  "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
  "version": "1.0",
  "pathFilters": ["."]
  "publicReleaseRefSpec": [ "^refs/heads/master$"]
}
```