### PR TITLE
Emit placeholder Git metadata when Git engine is disabled

### DIFF
--- a/src/Nerdbank.GitVersioning.Tasks/GetBuildVersion.cs
+++ b/src/Nerdbank.GitVersioning.Tasks/GetBuildVersion.cs
@@ -11,6 +11,12 @@ namespace Nerdbank.GitVersioning.Tasks
 {
     public class GetBuildVersion : ContextAwareTask
     {
+        private const string UnavailableGitValue = "Unavailable from a shallow git clone";
+        private const string UnavailableGitWarningCode = "NBGV1001";
+
+        // October 26, 1985 at 1:21 AM UTC, when the DeLorean first traveled through time.
+        private const string UnavailableGitDateTicks = "626347344600000000";
+
         /// <summary>
         /// Initializes a new instance of the <see cref="GetBuildVersion"/> class.
         /// </summary>
@@ -286,6 +292,24 @@ namespace Nerdbank.GitVersioning.Tasks
                 this.GitCommitIdShort = oracle.GitCommitIdShort;
                 this.GitCommitDateTicks = oracle.GitCommitDate is not null ? oracle.GitCommitDate.Value.UtcTicks.ToString(CultureInfo.InvariantCulture) : null;
                 this.GitCommitAuthorDateTicks = oracle.GitCommitAuthorDate is not null ? oracle.GitCommitAuthorDate.Value.UtcTicks.ToString(CultureInfo.InvariantCulture) : null;
+                if (engine == GitContext.Engine.Disabled)
+                {
+                    this.GitCommitId = UnavailableGitValue;
+                    this.GitCommitIdShort = UnavailableGitValue;
+                    this.GitCommitDateTicks = UnavailableGitDateTicks;
+                    this.GitCommitAuthorDateTicks = UnavailableGitDateTicks;
+                    this.Log.LogWarning(
+                        subcategory: null,
+                        warningCode: UnavailableGitWarningCode,
+                        helpKeyword: null,
+                        file: null,
+                        lineNumber: 0,
+                        columnNumber: 0,
+                        endLineNumber: 0,
+                        endColumnNumber: 0,
+                        message: "Git information is unavailable because the git engine is disabled. ThisAssembly.GitCommitId, ThisAssembly.GitCommitDate, and ThisAssembly.GitCommitAuthorDate contain placeholder values.");
+                }
+
                 this.GitVersionHeight = oracle.VersionHeight;
                 this.BuildMetadataFragment = oracle.BuildMetadataFragment;
                 this.CloudBuildNumber = oracle.CloudBuildNumberEnabled ? oracle.CloudBuildNumber : null;

--- a/src/Nerdbank.GitVersioning.Tasks/GetBuildVersion.cs
+++ b/src/Nerdbank.GitVersioning.Tasks/GetBuildVersion.cs
@@ -307,7 +307,7 @@ namespace Nerdbank.GitVersioning.Tasks
                         columnNumber: 0,
                         endLineNumber: 0,
                         endColumnNumber: 0,
-                        message: "Git information is unavailable because the git engine is disabled. ThisAssembly.GitCommitId, ThisAssembly.GitCommitDate, and ThisAssembly.GitCommitAuthorDate contain placeholder values.");
+                        message: "Git information is unavailable because the git engine is disabled. Git-related MSBuild properties and ThisAssembly members contain placeholder values.");
                 }
 
                 this.GitVersionHeight = oracle.VersionHeight;

--- a/test/Nerdbank.GitVersioning.Tests/BuildIntegrationDisabledTests.cs
+++ b/test/Nerdbank.GitVersioning.Tests/BuildIntegrationDisabledTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation and Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Microsoft.Build.Framework;
 using Nerdbank.GitVersioning;
 using Xunit;
 
@@ -13,6 +14,33 @@ public class BuildIntegrationDisabledTests : BuildIntegrationTests
     public BuildIntegrationDisabledTests(ITestOutputHelper logger)
         : base(logger)
     {
+    }
+
+    [Fact]
+    public async Task ThisAssemblyGitPropertiesHavePlaceholders()
+    {
+        this.WriteVersionFile();
+
+        BuildResults result = await this.BuildAsync(Targets.GenerateAssemblyNBGVVersionInfo);
+        string versionSourceFile = result.BuildResult.ProjectStateAfterBuild.GetPropertyValue("VersionSourceFile");
+        string generatedCode = File.ReadAllText(Path.Combine(this.projectDirectory, versionSourceFile));
+
+        Assert.Contains("internal const string GitCommitId = \"Unavailable from a shallow git clone\";", generatedCode);
+        Assert.Contains("internal static readonly global::System.DateTime GitCommitDate = new global::System.DateTime(626347344600000000L, global::System.DateTimeKind.Utc);", generatedCode);
+        Assert.Contains("internal static readonly global::System.DateTime GitCommitAuthorDate = new global::System.DateTime(626347344600000000L, global::System.DateTimeKind.Utc);", generatedCode);
+        BuildWarningEventArgs warning = Assert.Single(result.LoggedEvents.OfType<BuildWarningEventArgs>(), warning => warning.Code == "NBGV1001");
+        Assert.Contains("contain placeholder values", warning.Message);
+    }
+
+    [Fact]
+    public async Task PlaceholderWarningCanBeSuppressed()
+    {
+        this.WriteVersionFile();
+        this.globalProperties["MSBuildWarningsAsMessages"] = "NBGV1001";
+
+        BuildResults result = await this.BuildAsync(Targets.GenerateAssemblyNBGVVersionInfo);
+
+        Assert.DoesNotContain(result.LoggedEvents.OfType<BuildWarningEventArgs>(), warning => warning.Code == "NBGV1001");
     }
 
     protected override GitContext CreateGitContext(string path, string committish = null)


### PR DESCRIPTION
Disabling the Git engine currently omits Git-backed `ThisAssembly` members, which can break compilation for projects that reference them. Keep the generated API shape stable by emitting explicit placeholder metadata whenever Git access is disabled.

The string metadata reports `Unavailable from a shallow git clone`, while the machine-readable commit dates use the recognizable Back to the Future timestamp of October 26, 1985 at 1:21 AM UTC. Builds emit suppressible warning `NBGV1001` so consumers cannot silently mistake these placeholders for real source metadata; users can opt out through `MSBuildWarningsAsMessages`.

Integration coverage verifies the generated members, values, warning code, and warning suppression.

Fixes #1192