### PR TITLE
Add optional dirty flag to commit versions

### DIFF
--- a/docfx/docs/versionJson.md
+++ b/docfx/docs/versionJson.md
@@ -39,6 +39,7 @@ The content of the version.json file is a JSON serialized object with these prop
   "semVer1NumericIdentifierPadding": 4, // optional. Use when your -prerelease includes numeric identifiers and need semver1 support.
   "gitCommitIdShortFixedLength": 10, // optional. Set the commit ID abbreviation length.
   "gitCommitIdShortAutoMinimum": 0, // optional. Set to use the short commit ID abbreviation provided by the git repository.
+  "gitCommitIdIncludeDirty": false, // optional. Append "-dirty" to commit IDs and the assembly informational version for uncommitted changes.
   "nugetPackageVersion": {
      "semVer": 1 // optional. Set to either 1 or 2 to control how the NuGet package version string is generated. Default is 1.
      "precision": "build" // optional. Use when you want to use a more or less precise package version than the default major.minor.build.

--- a/src/NerdBank.GitVersioning/GitContext.cs
+++ b/src/NerdBank.GitVersioning/GitContext.cs
@@ -129,6 +129,11 @@ public abstract class GitContext : IDisposable
     public abstract IReadOnlyCollection<string>? HeadTags { get; }
 
     /// <summary>
+    /// Gets a value indicating whether the working tree has uncommitted changes.
+    /// </summary>
+    internal virtual bool IsWorkingTreeDirty => false;
+
+    /// <summary>
     /// Gets the path to the .git folder.
     /// </summary>
     protected string? DotGitPath { get; }

--- a/src/NerdBank.GitVersioning/LibGit2/LibGit2Context.cs
+++ b/src/NerdBank.GitVersioning/LibGit2/LibGit2Context.cs
@@ -83,6 +83,9 @@ public class LibGit2Context : GitContext
         }
     }
 
+    /// <inheritdoc />
+    internal override bool IsWorkingTreeDirty => this.Repository.RetrieveStatus().IsDirty;
+
     private string DebuggerDisplay => $"\"{this.WorkingTreePath}\" (libgit2)";
 
     /// <summary>Initializes a new instance of the <see cref="LibGit2Context"/> class.</summary>

--- a/src/NerdBank.GitVersioning/Managed/ManagedGitContext.cs
+++ b/src/NerdBank.GitVersioning/Managed/ManagedGitContext.cs
@@ -67,6 +67,9 @@ public class ManagedGitContext : GitContext
         get => this.headTags ??= this.Repository.Lookup("HEAD") is GitObjectId head ? this.Repository.LookupTags(head) : null;
     }
 
+    /// <inheritdoc />
+    internal override bool IsWorkingTreeDirty => this.Repository.IsWorkingTreeDirty();
+
     private string DebuggerDisplay => $"\"{this.WorkingTreePath}\" (managed)";
 
     /// <summary>Initializes a new instance of the <see cref="ManagedGitContext"/> class.</summary>

--- a/src/NerdBank.GitVersioning/ManagedGit/GitRepository.cs
+++ b/src/NerdBank.GitVersioning/ManagedGit/GitRepository.cs
@@ -3,6 +3,7 @@
 
 #nullable enable
 
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Runtime.InteropServices;
@@ -774,6 +775,36 @@ public class GitRepository : IDisposable
                 pack.Dispose();
             }
         }
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether the index or working tree has uncommitted changes.
+    /// </summary>
+    /// <returns><see langword="true"/> when the repository is dirty; otherwise, <see langword="false"/>.</returns>
+    internal bool IsWorkingTreeDirty()
+    {
+        var startInfo = new ProcessStartInfo("git")
+        {
+            Arguments = "status --porcelain=v1 --untracked-files=normal",
+            CreateNoWindow = true,
+            RedirectStandardError = true,
+            RedirectStandardOutput = true,
+            UseShellExecute = false,
+            WorkingDirectory = this.WorkingDirectory,
+        };
+
+        using Process process = Process.Start(startInfo) ?? throw new GitException("Failed to start Git while checking the working tree status.");
+        Task<string> standardOutputTask = process.StandardOutput.ReadToEndAsync();
+        Task<string> standardErrorTask = process.StandardError.ReadToEndAsync();
+        process.WaitForExit();
+        string standardOutput = standardOutputTask.GetAwaiter().GetResult();
+        string standardError = standardErrorTask.GetAwaiter().GetResult();
+        if (process.ExitCode != 0)
+        {
+            throw new GitException($"Git failed while checking the working tree status: {standardError.Trim()}");
+        }
+
+        return standardOutput.Length > 0;
     }
 
     /// <summary>

--- a/src/NerdBank.GitVersioning/VersionOptions.cs
+++ b/src/NerdBank.GitVersioning/VersionOptions.cs
@@ -98,6 +98,12 @@ public class VersionOptions : IEquatable<VersionOptions>
     private int? gitCommitIdShortAutoMinimum;
 
     /// <summary>
+    /// Backing field for the <see cref="GitCommitIdIncludeDirty"/> property.
+    /// </summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    private bool? gitCommitIdIncludeDirty;
+
+    /// <summary>
     /// Backing field for the <see cref="NuGetPackageVersion"/> property.
     /// </summary>
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
@@ -162,6 +168,7 @@ public class VersionOptions : IEquatable<VersionOptions>
         this.semVer1NumericIdentifierPadding = copyFrom.semVer1NumericIdentifierPadding;
         this.gitCommitIdShortFixedLength = copyFrom.gitCommitIdShortFixedLength;
         this.gitCommitIdShortAutoMinimum = copyFrom.gitCommitIdShortAutoMinimum;
+        this.gitCommitIdIncludeDirty = copyFrom.gitCommitIdIncludeDirty;
         this.nuGetPackageVersion = copyFrom.nuGetPackageVersion is object ? new NuGetPackageVersionOptions(copyFrom.nuGetPackageVersion) : null;
         this.publicReleaseRefSpec = copyFrom.publicReleaseRefSpec?.ToList();
         this.cloudBuild = copyFrom.cloudBuild is object ? new CloudBuildOptions(copyFrom.cloudBuild) : null;
@@ -471,6 +478,23 @@ public class VersionOptions : IEquatable<VersionOptions>
         get => this.gitCommitIdShortAutoMinimum;
         set => this.SetIfNotReadOnly(ref this.gitCommitIdShortAutoMinimum, value);
     }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether Git commit IDs should be suffixed with <c>-dirty</c>
+    /// when the working tree has uncommitted changes.
+    /// </summary>
+    [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+    public bool? GitCommitIdIncludeDirty
+    {
+        get => this.gitCommitIdIncludeDirty;
+        set => this.SetIfNotReadOnly(ref this.gitCommitIdIncludeDirty, value);
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether Git commit IDs should indicate a dirty working tree.
+    /// </summary>
+    [JsonIgnore]
+    public bool GitCommitIdIncludeDirtyOrDefault => this.GitCommitIdIncludeDirty ?? false;
 
     /// <summary>
     /// Gets or sets the options around NuGet version strings.

--- a/src/NerdBank.GitVersioning/VersionOracle.cs
+++ b/src/NerdBank.GitVersioning/VersionOracle.cs
@@ -25,6 +25,8 @@ public class VersionOracle
 
     private readonly string? gitCommitId;
 
+    private readonly bool isWorkingTreeDirty;
+
     private readonly string? versionGitCommitId;
 
     private readonly string? versionGitCommitIdShort;
@@ -45,8 +47,8 @@ public class VersionOracle
     public VersionOracle(GitContext context, ICloudBuild? cloudBuild = null, int? overrideVersionHeightOffset = null)
     {
         this.context = context;
-        this.gitCommitId = context.GitCommitId ?? cloudBuild?.GitCommitId;
-
+        string? rawGitCommitId = context.GitCommitId ?? cloudBuild?.GitCommitId;
+        this.gitCommitId = rawGitCommitId;
         this.CommittedVersion = context.VersionFile.GetVersion();
 
         // Consider the working version only if the commit being inspected is HEAD.
@@ -89,6 +91,8 @@ public class VersionOracle
         static Exception ThrowShallowClone(Exception inner) => throw new GitException("Shallow clone lacks the objects required to calculate version height. Use full clones or clones with a history at least as deep as the last version height resetting change.", inner) { IsShallowClone = true, ErrorCode = GitException.ErrorCodes.ObjectNotFound };
 
         this.VersionOptions = this.CommittedVersion ?? this.WorkingVersion;
+        this.isWorkingTreeDirty = context.IsHead && this.VersionOptions?.GitCommitIdIncludeDirtyOrDefault == true && context.IsWorkingTreeDirty;
+        this.gitCommitId = this.isWorkingTreeDirty && !string.IsNullOrEmpty(rawGitCommitId) ? rawGitCommitId + "-dirty" : rawGitCommitId;
         this.Version = this.VersionOptions?.Version?.Version ?? Version0;
         this.assemblyInformationalVersionComponentCount = this.VersionOptions?.VersionHeightPosition == SemanticVersion.Position.Revision ? 4 : 3;
 
@@ -113,9 +117,10 @@ public class VersionOracle
             int gitCommitIdShortAutoMinimum = this.VersionOptions?.GitCommitIdShortAutoMinimum ?? 0;
 
             // Get it from the git repository if there is a repository present and it is enabled.
-            this.GitCommitIdShort = gitCommitIdShortAutoMinimum > 0
+            string gitCommitIdShort = gitCommitIdShortAutoMinimum > 0
                 ? this.context.GetShortUniqueCommitId(gitCommitIdShortAutoMinimum)
-                : this.GitCommitId!.Substring(0, gitCommitIdShortFixedLength);
+                : rawGitCommitId!.Substring(0, gitCommitIdShortFixedLength);
+            this.GitCommitIdShort = this.isWorkingTreeDirty ? gitCommitIdShort + "-dirty" : gitCommitIdShort;
         }
 
         if (!string.IsNullOrEmpty(this.versionGitCommitId))

--- a/src/NerdBank.GitVersioning/version.schema.json
+++ b/src/NerdBank.GitVersioning/version.schema.json
@@ -104,6 +104,11 @@
           "default": 0,
           "maximum": 40
         },
+        "gitCommitIdIncludeDirty": {
+          "type": "boolean",
+          "description": "Whether to append '-dirty' to Git commit IDs and the assembly informational version when the working tree has uncommitted changes.",
+          "default": false
+        },
         "nugetPackageVersion": {
           "type": "object",
           "description": "Details for how and what the generated version for NuGet packages will be.",

--- a/test/Nerdbank.GitVersioning.Tests/VersionOracleTests.cs
+++ b/test/Nerdbank.GitVersioning.Tests/VersionOracleTests.cs
@@ -112,6 +112,65 @@ public abstract class VersionOracleTests : RepoTestBase
     }
 
     [Fact]
+    public void DirtyCommitIdDisabledByDefault()
+    {
+        this.WriteVersionFile(new VersionOptions { Version = SemanticVersion.Parse("1.2") });
+        File.WriteAllText(Path.Combine(this.RepoPath, "tracked.txt"), "original");
+        this.InitializeSourceControl();
+        File.WriteAllText(Path.Combine(this.RepoPath, "tracked.txt"), "changed");
+
+        var oracle = new VersionOracle(this.Context);
+
+        Assert.Equal(this.Context.GitCommitId, oracle.GitCommitId);
+        Assert.Equal(this.CommitIdShort, oracle.GitCommitIdShort);
+        Assert.DoesNotContain("dirty", oracle.AssemblyInformationalVersion);
+    }
+
+    [Fact]
+    public void DirtyTrackedFileMarkedInCommitIds()
+    {
+        this.WriteVersionFile(new VersionOptions { Version = SemanticVersion.Parse("1.2"), GitCommitIdIncludeDirty = true });
+        File.WriteAllText(Path.Combine(this.RepoPath, "tracked.txt"), "original");
+        this.InitializeSourceControl();
+        File.WriteAllText(Path.Combine(this.RepoPath, "tracked.txt"), "changed");
+
+        var oracle = new VersionOracle(this.Context);
+
+        Assert.Equal(this.Context.GitCommitId + "-dirty", oracle.GitCommitId);
+        Assert.Equal(this.CommitIdShort + "-dirty", oracle.GitCommitIdShort);
+        Assert.EndsWith("+" + this.CommitIdShort + "-dirty", oracle.AssemblyInformationalVersion);
+    }
+
+    [Fact]
+    public void DirtyUntrackedFileMarkedInCommitIds()
+    {
+        this.WriteVersionFile(new VersionOptions { Version = SemanticVersion.Parse("1.2"), GitCommitIdIncludeDirty = true });
+        this.InitializeSourceControl();
+        File.WriteAllText(Path.Combine(this.RepoPath, "untracked.txt"), "content");
+
+        var oracle = new VersionOracle(this.Context);
+
+        Assert.Equal(this.Context.GitCommitId + "-dirty", oracle.GitCommitId);
+        Assert.Equal(this.CommitIdShort + "-dirty", oracle.GitCommitIdShort);
+        Assert.EndsWith("+" + this.CommitIdShort + "-dirty", oracle.AssemblyInformationalVersion);
+    }
+
+    [Fact]
+    public void IgnoredFileDoesNotMarkCommitIdsDirty()
+    {
+        this.WriteVersionFile(new VersionOptions { Version = SemanticVersion.Parse("1.2"), GitCommitIdIncludeDirty = true });
+        File.WriteAllText(Path.Combine(this.RepoPath, ".gitignore"), "ignored.txt");
+        this.InitializeSourceControl();
+        File.WriteAllText(Path.Combine(this.RepoPath, "ignored.txt"), "content");
+
+        var oracle = new VersionOracle(this.Context);
+
+        Assert.Equal(this.Context.GitCommitId, oracle.GitCommitId);
+        Assert.Equal(this.CommitIdShort, oracle.GitCommitIdShort);
+        Assert.EndsWith("+" + this.CommitIdShort, oracle.AssemblyInformationalVersion);
+    }
+
+    [Fact]
     public void MajorMinorPrereleaseBuildMetadata()
     {
         VersionOptions workingCopyVersion = new VersionOptions


### PR DESCRIPTION
Uncommitted changes can make a build impossible to reproduce from its reported commit. This adds an opt-in `gitCommitIdIncludeDirty` setting that appends `-dirty` to `GitCommitId`, `GitCommitIdShort`, and `AssemblyInformationalVersion` when the working tree has changes, while preserving existing output by default.

Managed Git and LibGit2 determine status independently. Shared tests run against both engines and cover clean repositories, tracked and untracked changes, ignored files, and the disabled-by-default behavior. This also guards against LibGit2 status checks falsely marking a clean repository dirty.

Fixes #479