### PR TITLE
Warn when get-version reads dirty version files

### DIFF
--- a/src/nbgv/Program.cs
+++ b/src/nbgv/Program.cs
@@ -704,6 +704,7 @@ namespace Nerdbank.GitVersioning.Tool
             }
 
             var oracle = new VersionOracle(context, CloudBuild.Active);
+            WarnIfVersionJsonIsDirty(context);
             if (metadata is not null)
             {
                 oracle.BuildMetadata.AddRange(metadata);
@@ -767,6 +768,67 @@ namespace Nerdbank.GitVersioning.Tool
             }
 
             return Task.FromResult((int)ExitCodes.OK);
+        }
+
+        private static void WarnIfVersionJsonIsDirty(GitContext context)
+        {
+            if (!context.IsHead)
+            {
+                return;
+            }
+
+            context.VersionFile.GetVersion(VersionFileRequirements.Default, out VersionFileLocations committedLocations);
+            context.VersionFile.GetWorkingCopyVersion(VersionFileRequirements.Default, out VersionFileLocations workingLocations);
+
+            using var repository = new LibGit2Sharp.Repository(context.WorkingTreePath);
+            var versionJsonPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            AddVersionJsonPaths(committedLocations, fromWorkingTree: false);
+            AddVersionJsonPaths(workingLocations, fromWorkingTree: true);
+
+            if (versionJsonPaths.Count > 0
+                && repository.RetrieveStatus(
+                    new LibGit2Sharp.StatusOptions
+                    {
+                        IncludeUntracked = true,
+                        RecurseUntrackedDirs = true,
+                        PathSpec = versionJsonPaths.ToArray(),
+                    }).Any())
+            {
+                Console.Error.WriteLine("Warning: Dirty version.json files must be committed before their changes will be applied.");
+            }
+
+            void AddVersionJsonPaths(VersionFileLocations locations, bool fromWorkingTree)
+            {
+                string lastDirectory = locations.NonInheritingVersionDirectory ?? locations.VersionSpecifyingVersionDirectory;
+                if (lastDirectory is null)
+                {
+                    return;
+                }
+
+                for (string directory = context.AbsoluteProjectDirectory; directory is not null; directory = Path.GetDirectoryName(directory))
+                {
+                    string repoRelativeDirectory = Path.GetRelativePath(context.WorkingTreePath, directory).Replace('\\', '/');
+                    if (repoRelativeDirectory == ".")
+                    {
+                        repoRelativeDirectory = string.Empty;
+                    }
+
+                    string versionJsonPath = Path.Combine(repoRelativeDirectory, VersionFile.JsonFileName).Replace('\\', '/');
+                    string versionTxtPath = Path.Combine(repoRelativeDirectory, VersionFile.TxtFileName).Replace('\\', '/');
+                    bool versionJsonWasRead = fromWorkingTree
+                        ? File.Exists(Path.Combine(directory, VersionFile.JsonFileName)) && !File.Exists(Path.Combine(directory, VersionFile.TxtFileName))
+                        : repository.Head.Tip.Tree[versionJsonPath] is not null && repository.Head.Tip.Tree[versionTxtPath] is null;
+                    if (versionJsonWasRead)
+                    {
+                        versionJsonPaths.Add(versionJsonPath);
+                    }
+
+                    if (string.Equals(directory, lastDirectory, StringComparison.OrdinalIgnoreCase))
+                    {
+                        break;
+                    }
+                }
+            }
         }
 
         private static Task<int> OnSetVersionCommand(string project, string version)

--- a/test/Nerdbank.GitVersioning.Tests/NbgvInstallTests.cs
+++ b/test/Nerdbank.GitVersioning.Tests/NbgvInstallTests.cs
@@ -123,6 +123,54 @@ public class NbgvInstallTests : RepoTestBase
         Assert.Equal("^refs/heads/release/v1\\.0$", (string?)versionOptions["publicReleaseRefSpec"]?[0]);
     }
 
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task GetVersionWarnsWhenVersionJsonIsDirty(bool staged)
+    {
+        this.WriteVersionFile();
+        this.InitializeSourceControl();
+        string versionJsonPath = Path.Combine(this.RepoPath, VersionFile.JsonFileName);
+        File.WriteAllText(versionJsonPath, """{"version":"2.0"}""");
+        if (staged)
+        {
+            LibGit2Sharp.Commands.Stage(this.LibGit2Repository, VersionFile.JsonFileName);
+        }
+
+        (int exitCode, string standardError) = await this.RunNbgvGetVersionAsync(this.RepoPath);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("Dirty version.json files must be committed before their changes will be applied.", standardError);
+    }
+
+    [Fact]
+    public async Task GetVersionWarnsWhenInheritedVersionJsonIsDirty()
+    {
+        this.WriteVersionFile();
+        this.WriteVersionFile(new VersionOptions { Inherit = true }, "src");
+        this.InitializeSourceControl();
+        File.WriteAllText(Path.Combine(this.RepoPath, VersionFile.JsonFileName), """{"version":"2.0"}""");
+
+        (int exitCode, string standardError) = await this.RunNbgvGetVersionAsync(Path.Combine(this.RepoPath, "src"));
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("Dirty version.json files must be committed before their changes will be applied.", standardError);
+    }
+
+    [Fact]
+    public async Task GetVersionDoesNotWarnForUnreadVersionJson()
+    {
+        this.WriteVersionFile();
+        this.WriteVersionFile("2.0", relativeDirectory: "src");
+        this.InitializeSourceControl();
+        File.WriteAllText(Path.Combine(this.RepoPath, VersionFile.JsonFileName), """{"version":"3.0"}""");
+
+        (int exitCode, string standardError) = await this.RunNbgvGetVersionAsync(Path.Combine(this.RepoPath, "src"));
+
+        Assert.Equal(0, exitCode);
+        Assert.DoesNotContain("Dirty version.json files", standardError);
+    }
+
     protected override GitContext CreateGitContext(string path, string? committish = null)
         => GitContext.Create(path, committish, engine: GitContext.Engine.ReadWrite);
 
@@ -160,6 +208,34 @@ public class NbgvInstallTests : RepoTestBase
         catch (OperationCanceledException)
         {
         }
+    }
+
+    private async Task<(int ExitCode, string StandardError)> RunNbgvGetVersionAsync(string project)
+    {
+        string nbgvToolPath = typeof(NbgvInstallTests).Assembly
+            .GetCustomAttributes<AssemblyMetadataAttribute>()
+            .Single(attribute => attribute.Key == "NbgvToolPath")
+            .Value!;
+        var startInfo = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardError = true,
+            RedirectStandardOutput = true,
+            UseShellExecute = false,
+        };
+        startInfo.ArgumentList.Add(nbgvToolPath);
+        startInfo.ArgumentList.Add("get-version");
+        startInfo.ArgumentList.Add("--project");
+        startInfo.ArgumentList.Add(project);
+        startInfo.Environment["NBGV_GitEngine"] = "Managed";
+
+        using Process process = Process.Start(startInfo)!;
+        Task<string> standardOutputTask = process.StandardOutput.ReadToEndAsync(TestContext.Current.CancellationToken);
+        Task<string> standardErrorTask = process.StandardError.ReadToEndAsync(TestContext.Current.CancellationToken);
+        await Task.WhenAll(standardOutputTask, standardErrorTask, process.WaitForExitAsync(TestContext.Current.CancellationToken));
+        string standardError = await standardErrorTask;
+        this.Logger.WriteLine("nbgv standard output:{0}{1}", Environment.NewLine, await standardOutputTask);
+        this.Logger.WriteLine("nbgv standard error:{0}{1}", Environment.NewLine, standardError);
+        return (process.ExitCode, standardError);
     }
 }
 #endif


### PR DESCRIPTION
Dirty `version.json` changes can be confusing because version calculation continues to use committed configuration. This adds an STDERR warning from `nbgv get-version` when a `version.json` it reads differs from HEAD in either the index or working tree.

The check follows both direct and inherited version-file chains while avoiding warnings for unrelated dirty files or JSON files shadowed by `version.txt`. Integration coverage includes staged, unstaged, inherited, and unread version files.

Closes #229