### PR TITLE
Update Library.Template tooling and test runner

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # Refer to https://hub.docker.com/_/microsoft-dotnet-sdk for available versions
-FROM mcr.microsoft.com/dotnet/sdk:10.0.302@sha256:72dd743782f2ae7e5476fd64f6a460045e3998dc862218b80e6944cba79a01b0
+FROM mcr.microsoft.com/dotnet/sdk:10.0.400@sha256:e1fc6e423f543119c406d24e2e687d67c569f18f04a37a8b0005d80ad0dcee80
 
 # Installing mono makes `dotnet test` work without errors even for net472.
 # But installing it takes a long time, so it's excluded by default.

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.302",
+    "version": "10.0.400",
     "rollForward": "patch",
     "allowPrerelease": false
   },

--- a/tools/Install-DotNetSdk.ps1
+++ b/tools/Install-DotNetSdk.ps1
@@ -99,9 +99,9 @@ if (!$IncludeAspNetCore) {
     $aspnetRuntimeVersions = @()
 }
 
-Function Get-FileFromWeb([Uri]$Uri, $OutDir) {
+Function Get-FileFromWeb([Uri]$Uri, $OutDir, [switch]$Force) {
     $OutFile = Join-Path $OutDir $Uri.Segments[-1]
-    if (!(Test-Path $OutFile)) {
+    if ($Force -or !(Test-Path $OutFile)) {
         Write-Verbose "Downloading $Uri..."
         if (!(Test-Path $OutDir)) { New-Item -ItemType Directory -Path $OutDir | Out-Null }
         try {
@@ -134,38 +134,49 @@ Function Get-InstallerExe(
 
     $majorMinor = "$($TypedVersion.Major).$($TypedVersion.Minor)"
     $ReleasesFile = Join-Path $DotNetInstallScriptRoot "$majorMinor\releases.json"
-    if (!(Test-Path $ReleasesFile)) {
-        Get-FileFromWeb -Uri "https://builds.dotnet.microsoft.com/dotnet/release-metadata/$majorMinor/releases.json" -OutDir (Split-Path $ReleasesFile) | Out-Null
+    $ReleasesFileWasCached = Test-Path $ReleasesFile
+    $ReleasesUri = "https://builds.dotnet.microsoft.com/dotnet/release-metadata/$majorMinor/releases.json"
+    if (!$ReleasesFileWasCached) {
+        Get-FileFromWeb -Uri $ReleasesUri -OutDir (Split-Path $ReleasesFile) | Out-Null
     }
 
-    $releases = Get-Content $ReleasesFile | ConvertFrom-Json
     $url = $null
-    foreach ($release in $releases.releases) {
-        $filesElement = $null
-        if ($release.$sku.version -eq $Version) {
-            $filesElement = $release.$sku.files
-        }
-        if (!$filesElement -and ($sku -eq 'sdk') -and $release.sdks) {
-            foreach ($sdk in $release.sdks) {
-                if ($sdk.version -eq $Version) {
-                    $filesElement = $sdk.files
-                    break
+    for ($attempt = 0; $attempt -lt 2; $attempt++) {
+        $releases = Get-Content $ReleasesFile | ConvertFrom-Json
+        foreach ($release in $releases.releases) {
+            $filesElement = $null
+            if ($release.$sku.version -eq $Version) {
+                $filesElement = $release.$sku.files
+            }
+            if (!$filesElement -and ($sku -eq 'sdk') -and $release.sdks) {
+                foreach ($sdk in $release.sdks) {
+                    if ($sdk.version -eq $Version) {
+                        $filesElement = $sdk.files
+                        break
+                    }
                 }
             }
-        }
 
-        if ($filesElement) {
-            foreach ($file in $filesElement) {
-                if ($file.rid -eq "win-$Architecture") {
-                    $url = $file.url
+            if ($filesElement) {
+                foreach ($file in $filesElement) {
+                    if ($file.rid -eq "win-$Architecture") {
+                        $url = $file.url
+                        Break
+                    }
+                }
+
+                if ($url) {
                     Break
                 }
             }
-
-            if ($url) {
-                Break
-            }
         }
+
+        if ($url -or !$ReleasesFileWasCached -or $attempt -gt 0) {
+            break
+        }
+
+        Write-Verbose "Release not found in cached metadata. Refreshing $ReleasesUri..."
+        Get-FileFromWeb -Uri $ReleasesUri -OutDir (Split-Path $ReleasesFile) -Force | Out-Null
     }
 
     if ($url) {

--- a/tools/artifacts/testResults.ps1
+++ b/tools/artifacts/testResults.ps1
@@ -4,21 +4,25 @@ Param(
 
 $result = @{}
 
+# Hang and crash dumps are copied into the TRX attachment directory when a TRX report is requested.
+# Prefer that copy to avoid uploading the same dump twice, but keep the original when no attachment
+# copy exists (e.g. GitHub Actions runs, which don't request a TRX report) so crashes stay diagnosable.
+function Select-TestResultFile($files) {
+    $attachedDumpNames = @($files | Where-Object { $_.Extension -eq '.dmp' -and $_.FullName -match '[/\\]In[/\\]' } | ForEach-Object { $_.Name })
+    $files | Where-Object { $_.Extension -ne '.dmp' -or $_.FullName -match '[/\\]In[/\\]' -or $attachedDumpNames -notcontains $_.Name }
+}
+
 $RepoRoot = Resolve-Path "$PSScriptRoot\..\.."
 $testRoot = Join-Path $RepoRoot test
 $legacyTestResults = Join-Path $testRoot TestResults
 if (Test-Path $legacyTestResults) {
-    $result[$testRoot] = Get-ChildItem $legacyTestResults -Recurse -Directory |
-        Get-ChildItem -Recurse -File |
-        Where-Object { $_.Extension -ne '.dmp' -or $_.FullName -match '[/\\]In[/\\]' }
+    $result[$testRoot] = Select-TestResultFile @(Get-ChildItem $legacyTestResults -Recurse -Directory | Get-ChildItem -Recurse -File)
 }
 
 $artifactStaging = & "$PSScriptRoot/../Get-ArtifactsStagingDirectory.ps1"
 $testlogsPath = Join-Path $artifactStaging "test_logs"
 if (Test-Path $testlogsPath) {
-    # Hang and crash dumps are copied into the TRX attachment directory.
-    $result[$testlogsPath] = Get-ChildItem $testlogsPath -Recurse |
-        Where-Object { $_.Extension -ne '.dmp' -or $_.FullName -match '[/\\]In[/\\]' }
+    $result[$testlogsPath] = Select-TestResultFile @(Get-ChildItem $testlogsPath -Recurse)
 }
 
 $result

--- a/tools/dotnet-test-cloud.ps1
+++ b/tools/dotnet-test-cloud.ps1
@@ -13,6 +13,8 @@
     A switch to run the tests in an x86 process.
 .PARAMETER dotnet32
     The path to a 32-bit dotnet executable to use.
+.PARAMETER NoCoverage
+    A switch to skip code coverage collection.
 #>
 [CmdletBinding()]
 Param(
@@ -20,7 +22,8 @@ Param(
     [string]$Agent='Local',
     [switch]$PublishResults,
     [switch]$x86,
-    [string]$dotnet32
+    [string]$dotnet32,
+    [switch]$NoCoverage
 )
 
 $RepoRoot = (Resolve-Path "$PSScriptRoot/..").Path
@@ -60,10 +63,12 @@ if ($isMTP) {
         ,'--hangdump'
         ,'--hangdump-timeout','120s'
         ,'--crashdump'
+        ,'--crashdump-type','Heap'
+        # The native crash report accompanies the dump and is often the only way to identify the
+        # faulting thread and instruction when a test host dies of an access violation on Linux.
+        ,'--crash-report-if-supported'
     )
     $mtpArgs = @(
-        ,'--coverage'
-        ,'--coverage-output-format','cobertura'
         ,'--diagnostic'
         ,'--diagnostic-output-directory',$testLogs
         ,'--diagnostic-verbosity','Information'
@@ -71,12 +76,19 @@ if ($isMTP) {
         ,'--report-trx'
     )
 
+    if (-not $NoCoverage) {
+        $mtpArgs += @(
+            ,'--coverage'
+            ,'--coverage-output-format','cobertura'
+            ,'--coverage-settings',"$PSScriptRoot/test.runsettings"
+        )
+    }
+
     & $dotnet test --solution $RepoRoot `
         --no-build `
         -c $Configuration `
         -bl:"$testBinLog" `
         --filter-not-trait 'TestCategory=FailsInCloudTest' `
-        --coverage-settings "$PSScriptRoot/test.runsettings" `
         @mtpArgs `
         @dumpSwitches `
         @extraArgs
@@ -85,17 +97,24 @@ if ($isMTP) {
     $trxFiles = Get-ChildItem -Recurse -Path $testLogs\*.trx
 } else {
     $testDiagLog = Join-Path $ArtifactStagingFolder (Join-Path test_logs diag.log)
+    $coverageArgs = @()
+    if (-not $NoCoverage) {
+        $coverageArgs = @(
+            ,'--collect','Code Coverage;Format=cobertura'
+            ,'--settings',"$PSScriptRoot/test.runsettings"
+        )
+    }
+
     & $dotnet test $RepoRoot `
         --no-build `
         -c $Configuration `
         --filter "TestCategory!=FailsInCloudTest" `
-        --collect "Code Coverage;Format=cobertura" `
-        --settings "$PSScriptRoot/test.runsettings" `
         --blame-hang-timeout 60s `
         --blame-crash `
         -bl:"$testBinLog" `
         --diag "$testDiagLog;TraceLevel=info" `
         --logger trx `
+        @coverageArgs `
         @extraArgs
     if ($LASTEXITCODE -ne 0) { $failedTests += 1 }
 


### PR DESCRIPTION
Bring the repo up to date with the latest Library.Template changes so local builds and CI use the same SDK/tooling path and test-runner behavior as the template.

This updates the repo to the template's .NET SDK and installer changes, including the 10.0.400 SDK pin and the more resilient SDK installer logic. It also resolves the merge conflict in the cloud test runner by keeping the repository's existing TRX/reporting behavior while retaining the incoming crash-dump diagnostics and updated MTP arguments.

Validation completed locally:
- dotnet restore succeeded
- dotnet build succeeded
- The cloud test script was exercised, but the net472 test host in this environment still hits an MSBuild discovery issue unrelated to the merge itself.