### PR TITLE
Fix shallow clone ancestor lookup diagnostics

### DIFF
--- a/src/NerdBank.GitVersioning/GitException.cs
+++ b/src/NerdBank.GitVersioning/GitException.cs
@@ -94,4 +94,16 @@ public class GitException : Exception
         info.AddValue(nameof(this.ErrorCode), (int)this.ErrorCode);
         info.AddValue(nameof(this.IsShallowClone), this.IsShallowClone);
     }
+
+    /// <summary>
+    /// Creates an exception that describes a shallow clone missing required history.
+    /// </summary>
+    /// <param name="innerException">The exception caused by the missing object.</param>
+    /// <returns>The shallow clone exception.</returns>
+    internal static GitException CreateShallowCloneException(Exception innerException)
+        => new("Shallow clone lacks the objects required to calculate version height. Use full clones or clones with a history at least as deep as the last version height resetting change.", innerException)
+        {
+            IsShallowClone = true,
+            ErrorCode = ErrorCodes.ObjectNotFound,
+        };
 }

--- a/src/NerdBank.GitVersioning/Managed/ManagedGitContext.cs
+++ b/src/NerdBank.GitVersioning/Managed/ManagedGitContext.cs
@@ -29,13 +29,13 @@ public class ManagedGitContext : GitContext
             throw new ArgumentException("No git repo found here.", nameof(workingDirectory));
         }
 
-        this.Commit = committish is null ? repo.GetHeadCommit() : (repo.Lookup(committish) is { } objectId ? (GitCommit?)repo.GetCommit(objectId) : null);
+        this.Repository = repo;
+        this.Commit = committish is null ? repo.GetHeadCommit() : this.LookupCommit(committish);
         if (this.Commit is null && committish is object)
         {
             throw new ArgumentException("No matching commit found.", nameof(committish));
         }
 
-        this.Repository = repo;
         this.VersionFile = new ManagedVersionFile(this);
     }
 
@@ -91,9 +91,9 @@ public class ManagedGitContext : GitContext
     /// <inheritdoc />
     public override bool TrySelectCommit(string committish)
     {
-        if (this.Repository.Lookup(committish) is { } objectId)
+        if (this.LookupCommit(committish) is { } commit)
         {
-            this.Commit = this.Repository.GetCommit(objectId);
+            this.Commit = commit;
             return true;
         }
 
@@ -222,5 +222,28 @@ public class ManagedGitContext : GitContext
         }
 
         return VersionExtensions.Create(baseVersion.Major, baseVersion.Minor, buildNumber, revision);
+    }
+
+    private GitCommit? LookupCommit(string committish)
+    {
+        GitObjectId? objectId = this.Repository.Lookup(committish, out GitException? missingObjectException);
+        if (missingObjectException is object && this.IsShallow)
+        {
+            throw GitException.CreateShallowCloneException(missingObjectException);
+        }
+
+        if (objectId is null)
+        {
+            return null;
+        }
+
+        try
+        {
+            return this.Repository.GetCommit(objectId.Value);
+        }
+        catch (GitException ex) when (this.IsShallow && ex.ErrorCode == GitException.ErrorCodes.ObjectNotFound)
+        {
+            throw GitException.CreateShallowCloneException(ex);
+        }
     }
 }

--- a/src/NerdBank.GitVersioning/ManagedGit/GitRepository.cs
+++ b/src/NerdBank.GitVersioning/ManagedGit/GitRepository.cs
@@ -343,12 +343,21 @@ public class GitRepository : IDisposable
     /// </summary>
     /// <param name="objectish">Any "objectish" string (e.g. commit ID (partial or full), branch name, tag name, "HEAD", or a first-parent ancestor).</param>
     /// <returns>The object ID referenced by <paramref name="objectish"/> if found; otherwise <see langword="null"/>.</returns>
-    public GitObjectId? Lookup(string objectish)
+    public GitObjectId? Lookup(string objectish) => this.Lookup(objectish, out _);
+
+    /// <summary>
+    /// Parses any committish to an object id.
+    /// </summary>
+    /// <param name="objectish">Any "objectish" string (e.g. commit ID (partial or full), branch name, tag name, "HEAD", or a first-parent ancestor).</param>
+    /// <param name="missingObjectException">Receives the exception for an object missing while resolving an ancestor, if any.</param>
+    /// <returns>The object ID referenced by <paramref name="objectish"/> if found; otherwise <see langword="null"/>.</returns>
+    public GitObjectId? Lookup(string objectish, out GitException? missingObjectException)
     {
+        missingObjectException = null;
         int ancestorOperatorIndex = objectish.IndexOf('~');
         if (ancestorOperatorIndex > 0)
         {
-            GitObjectId? objectId = this.Lookup(objectish.Substring(0, ancestorOperatorIndex));
+            GitObjectId? objectId = this.Lookup(objectish.Substring(0, ancestorOperatorIndex), out missingObjectException);
             if (objectId is null)
             {
                 return null;
@@ -377,7 +386,17 @@ public class GitRepository : IDisposable
 
                 for (int i = 0; i < generations; i++)
                 {
-                    GitObjectId? parent = this.GetCommit(objectId.Value).FirstParent;
+                    GitObjectId? parent;
+                    try
+                    {
+                        parent = this.GetCommit(objectId.Value).FirstParent;
+                    }
+                    catch (GitException ex) when (ex.ErrorCode == GitException.ErrorCodes.ObjectNotFound)
+                    {
+                        missingObjectException = ex;
+                        return null;
+                    }
+
                     if (parent is null)
                     {
                         return null;

--- a/src/NerdBank.GitVersioning/VersionOracle.cs
+++ b/src/NerdBank.GitVersioning/VersionOracle.cs
@@ -80,15 +80,13 @@ public class VersionOracle
         catch (GitException ex) when (context.IsShallow && ex.ErrorCode == GitException.ErrorCodes.ObjectNotFound)
         {
             // Our managed git implementation throws this on shallow clones.
-            throw ThrowShallowClone(ex);
+            throw GitException.CreateShallowCloneException(ex);
         }
         catch (InvalidOperationException ex) when (context.IsShallow && (ex.InnerException is NullReferenceException || ex.InnerException is LibGit2Sharp.NotFoundException))
         {
             // Libgit2 throws this on shallow clones.
-            throw ThrowShallowClone(ex);
+            throw GitException.CreateShallowCloneException(ex);
         }
-
-        static Exception ThrowShallowClone(Exception inner) => throw new GitException("Shallow clone lacks the objects required to calculate version height. Use full clones or clones with a history at least as deep as the last version height resetting change.", inner) { IsShallowClone = true, ErrorCode = GitException.ErrorCodes.ObjectNotFound };
 
         this.VersionOptions = this.CommittedVersion ?? this.WorkingVersion;
         this.isWorkingTreeDirty = context.IsHead && this.VersionOptions?.GitCommitIdIncludeDirtyOrDefault == true && context.IsWorkingTreeDirty;

--- a/test/Nerdbank.GitVersioning.Tests/GitContextTests.cs
+++ b/test/Nerdbank.GitVersioning.Tests/GitContextTests.cs
@@ -27,6 +27,23 @@ public class GitContextManagedTests : GitContextTests
         Assert.False(this.Context.TrySelectCommit(committish));
     }
 
+    [Fact]
+    public void SelectFirstParentAncestorInShallowRepository()
+    {
+        this.AddCommits();
+
+        string firstCommitSha = this.LibGit2Repository.Head.Tip.Parents.Single().Sha;
+        string firstCommitPath = Path.Combine(this.RepoPath, ".git", "objects", firstCommitSha.Substring(0, 2), firstCommitSha.Substring(2));
+        File.SetAttributes(firstCommitPath, FileAttributes.Normal);
+        File.Delete(firstCommitPath);
+        File.WriteAllText(Path.Combine(this.RepoPath, ".git", "shallow"), firstCommitSha);
+
+        GitException exception = Assert.Throws<GitException>(() => this.Context.TrySelectCommit("HEAD~1"));
+
+        Assert.True(exception.IsShallowClone);
+        Assert.Equal(GitException.ErrorCodes.ObjectNotFound, exception.ErrorCode);
+    }
+
     /// <inheritdoc/>
     protected override GitContext CreateGitContext(string path, string committish = null)
         => GitContext.Create(path, committish, engine: GitContext.Engine.ReadOnly);

--- a/test/Nerdbank.GitVersioning.Tests/ManagedGit/GitRepositoryTests.cs
+++ b/test/Nerdbank.GitVersioning.Tests/ManagedGit/GitRepositoryTests.cs
@@ -159,6 +159,23 @@ public class GitRepositoryTests : RepoTestBase
     }
 
     [Fact]
+    public void LookupReturnsNullWhenAncestorCommitIsMissing()
+    {
+        this.InitializeSourceControl();
+        this.AddCommits(2);
+
+        string firstCommitSha = this.LibGit2Repository.Head.Tip.Parents.Single().Sha;
+        string firstCommitPath = Path.Combine(this.RepoPath, ".git", "objects", firstCommitSha.Substring(0, 2), firstCommitSha.Substring(2));
+        File.SetAttributes(firstCommitPath, FileAttributes.Normal);
+        File.Delete(firstCommitPath);
+
+        using (var repository = GitRepository.Create(this.RepoPath))
+        {
+            Assert.Null(repository.Lookup("HEAD~2"));
+        }
+    }
+
+    [Fact]
     public void GetTreeEntryTest()
     {
         this.InitializeSourceControl();


### PR DESCRIPTION
Shallow clones could leak an `ObjectNotFound` exception while resolving a first-parent ancestor, bypassing the user-facing shallow-clone guidance.

`Lookup` now preserves its nullable contract while exposing a missing-ancestor cause to the managed context. The context converts that cause, or a missing selected commit, into the existing normalized shallow-clone diagnostic. The same exception factory is used by version-height calculation so both paths produce identical CLI behavior.

Added regressions for missing ancestor lookup and shallow commit selection.

Fixes #1474