### PR TITLE
Publish Rust crates to crates.io

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,17 +36,15 @@ jobs:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         fetch-depth: 0
-    - name: ⚙ Install current stable Rust
-      run: rustup toolchain install stable --profile minimal --component clippy,rustfmt
     - name: 💅 Verify formatted code
-      run: cargo +stable fmt --all --check
+      run: cargo fmt --all --check
       if: runner.os == 'Linux'
     - name: 📎 Lint
-      run: cargo +stable clippy --workspace --all-targets --all-features -- -D warnings
+      run: cargo clippy --workspace --all-targets --all-features -- -D warnings
     - name: 🧪 Test
-      run: cargo +stable test --workspace
+      run: cargo test --workspace
     - name: 📚 Verify public documentation
-      run: cargo +stable doc --workspace --no-deps
+      run: cargo doc --workspace --no-deps
       env:
         RUSTDOCFLAGS: -D warnings
 

--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -28,17 +28,15 @@ jobs:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         fetch-depth: 0
-    - name: ⚙ Install current stable Rust
-      run: rustup toolchain install stable --profile minimal --component clippy,rustfmt
     - name: 💅 Verify formatted code
-      run: cargo +stable fmt --all --check
+      run: cargo fmt --all --check
       if: runner.os == 'Linux'
     - name: 📎 Lint
-      run: cargo +stable clippy --workspace --all-targets --all-features -- -D warnings
+      run: cargo clippy --workspace --all-targets --all-features -- -D warnings
     - name: 🧪 Test
-      run: cargo +stable test --workspace
+      run: cargo test --workspace
     - name: 📚 Verify public documentation
-      run: cargo +stable doc --workspace --no-deps
+      run: cargo doc --workspace --no-deps
       env:
         RUSTDOCFLAGS: -D warnings
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,11 @@ on:
         required: false
         default: true
         type: boolean
+      publish_crates:
+        description: Push Rust crates
+        required: false
+        default: true
+        type: boolean
 
 run-name: ${{ github.ref_name }}
 
@@ -164,6 +169,18 @@ jobs:
 
           npm publish @publishArgs
         }
+
+    - name: 🔐 Authenticate to crates.io
+      uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
+      id: crates-io-auth
+      if: ${{ github.event_name != 'workflow_dispatch' || inputs.publish_crates }}
+
+    - name: 🚀 Push Rust crates
+      if: ${{ github.event_name != 'workflow_dispatch' || inputs.publish_crates }}
+      working-directory: src/nerdbank-gitversioning-rs
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ steps.crates-io-auth.outputs.token }}
+      run: cargo publish --workspace
 
     - name: 💽 Upload artifacts to release
       shell: pwsh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,7 @@ After publishing the release, the `.github/workflows/release.yml` workflow will 
 1. Find the most recent `.github/workflows/build.yml` GitHub workflow run of the tagged release.
 1. Upload the `deployables` artifact from that workflow run to your GitHub Release.
 1. If you have `NUGET_API_KEY` defined as a secret variable for your repo or org, any nuget packages in the `deployables` artifact will be pushed to nuget.org.
+1. Publish the Rust crates to crates.io using Trusted Publishing.
 
 ### Azure Pipelines
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.95.0"
+profile = "minimal"
+components = ["clippy", "rustfmt"]


### PR DESCRIPTION
Rust crates built by this repository need a release path to crates.io without long-lived registry credentials.

## Summary

- Publish the Rust workspace from the release workflow using crates.io Trusted Publishing via OIDC.
- Add a `publish_crates` dispatch input so manual releases can opt out.
- Pin Rust 1.95.0 and its required components in `rust-toolchain.toml`, which the build, merge-queue, and release workflows now use.

Closes #1473