### PR TITLE
Stamp Rust crates with the build version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,10 @@ jobs:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         fetch-depth: 0
+    - name: Install .NET SDK
+      uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+      with:
+        global-json-file: global.json
     - name: 🏷️ Stamp crate versions
       shell: pwsh
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,12 @@ jobs:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         fetch-depth: 0
+    - name: 🏷️ Stamp crate versions
+      shell: pwsh
+      run: |
+        dotnet tool restore
+        ./tools/Set-CargoVersion.ps1
+      working-directory: ${{ github.workspace }}
     - name: 💅 Verify formatted code
       run: cargo fmt --all --check
       if: runner.os == 'Linux'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -184,7 +184,7 @@ jobs:
         CARGO_REGISTRY_TOKEN: ${{ steps.crates-io-auth.outputs.token }}
       run: |
         ../../tools/Set-CargoVersion.ps1
-        cargo publish --workspace
+        cargo publish --workspace --allow-dirty
 
     - name: 💽 Upload artifacts to release
       shell: pwsh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,8 @@ jobs:
       id-token: write # Required for Azure and NuGet OIDC authentication
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        fetch-depth: 0
 
     - name: 🔎 Search for build of ${{ github.ref }}
       shell: pwsh
@@ -180,7 +182,9 @@ jobs:
       working-directory: src/nerdbank-gitversioning-rs
       env:
         CARGO_REGISTRY_TOKEN: ${{ steps.crates-io-auth.outputs.token }}
-      run: cargo publish --workspace
+      run: |
+        ../../tools/Set-CargoVersion.ps1
+        cargo publish --workspace
 
     - name: 💽 Upload artifacts to release
       shell: pwsh

--- a/src/nerdbank-gitversioning-rs/Cargo.toml
+++ b/src/nerdbank-gitversioning-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nerdbank-gitversioning"
-version = "0.1.0"
+version.workspace = true
 edition = "2024"
 description = "Git-based semantic version calculation compatible with Nerdbank.GitVersioning"
 license = "MIT"
@@ -15,6 +15,9 @@ rust-version = "1.95"
 [workspace]
 members = ["nbgv"]
 resolver = "3"
+
+[workspace.dependencies]
+nerdbank-gitversioning = { version = "0.1.0", path = "." }
 
 [dependencies]
 bitflags = { version = "2.13.1", features = ["serde"] }
@@ -35,6 +38,7 @@ name = "get_version"
 harness = false
 
 [workspace.package]
+version = "0.1.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/dotnet/Nerdbank.GitVersioning"

--- a/src/nerdbank-gitversioning-rs/nbgv/Cargo.toml
+++ b/src/nerdbank-gitversioning-rs/nbgv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nbgv"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 description = "Command-line interface for Nerdbank.GitVersioning"
 license.workspace = true
@@ -15,7 +15,7 @@ rust-version.workspace = true
 [dependencies]
 clap = { version = "4.6.6", features = ["derive"] }
 git2 = { version = "0.21.0", default-features = false }
-nerdbank-gitversioning = { version = "0.1.0", path = ".." }
+nerdbank-gitversioning.workspace = true
 serde_json = "1.0.151"
 
 [dev-dependencies]

--- a/tools/Set-CargoVersion.ps1
+++ b/tools/Set-CargoVersion.ps1
@@ -1,0 +1,34 @@
+[CmdletBinding(SupportsShouldProcess)]
+Param(
+    [Parameter()]
+    [string]$Version
+)
+
+$repoRoot = Split-Path $PSScriptRoot -Parent
+$manifestPath = Join-Path $repoRoot 'src/nerdbank-gitversioning-rs/Cargo.toml'
+
+if (!$Version) {
+    $Version = dotnet tool run nbgv get-version -v NuGetPackageVersion
+    if ($LASTEXITCODE -ne 0) {
+        throw 'nbgv get-version failed.'
+    }
+}
+
+$manifest = Get-Content $manifestPath -Raw
+$patterns = @(
+    '(?m)(?<=^\[workspace\.package\]\r?\n)version = "[^"]+"',
+    '(?m)(?<=^nerdbank-gitversioning = \{ version = ")[^"]+(?=", path = "\." \}\r?$)'
+)
+
+foreach ($pattern in $patterns) {
+    if ([regex]::Matches($manifest, $pattern).Count -ne 1) {
+        throw "Expected exactly one match for '$pattern' in $manifestPath."
+    }
+}
+
+$manifest = [regex]::Replace($manifest, $patterns[0], "version = `"$Version`"")
+$manifest = [regex]::Replace($manifest, $patterns[1], $Version)
+
+if ($PSCmdlet.ShouldProcess($manifestPath, "Set Cargo package versions to $Version")) {
+    [System.IO.File]::WriteAllText($manifestPath, $manifest)
+}

--- a/tools/Set-CargoVersion.ps1
+++ b/tools/Set-CargoVersion.ps1
@@ -8,7 +8,7 @@ $repoRoot = Split-Path $PSScriptRoot -Parent
 $manifestPath = Join-Path $repoRoot 'src/nerdbank-gitversioning-rs/Cargo.toml'
 
 if (!$Version) {
-    $Version = dotnet tool run nbgv get-version -v NuGetPackageVersion
+    $Version = dotnet tool run nbgv get-version -v SemVer2
     if ($LASTEXITCODE -ne 0) {
         throw 'nbgv get-version failed.'
     }


### PR DESCRIPTION
Stamp the Rust crates with the `SemVer2` calculated by NB.GV

- Centralize both crate versions and the CLI's path dependency version in Cargo workspace metadata.
- Add a PowerShell helper that calculates the version through NBGV and fails if the expected manifest fields cannot be updated exactly once.
- Stamp versions before Rust CI validation and immediately before publishing to crates.io.
- Fetch full Git history in the release workflow so version height is calculated correctly.

Validation:
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace`
- Verified both crates and the path dependency resolve to the NBGV package version.