### PR TITLE
Respect EditorConfig final newline settings

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,6 +16,7 @@
     <PackageVersion Include="BenchmarkDotNet" Version="$(BenchmarkDotNetVersion)" />
     <PackageVersion Include="Cake.Core" Version="6.2.0" />
     <PackageVersion Include="DotNetMDDocs" Version="0.112.39" />
+    <PackageVersion Include="editorconfig" Version="0.17.0" />
     <PackageVersion Include="LibGit2Sharp.NativeBinaries" Version="$(LibGit2SharpNativeVersion)" />
     <PackageVersion Include="LibGit2Sharp" Version="0.32.0" />
     <PackageVersion Include="Microsoft.Build.Framework" Version="$(MSBuildPackageVersion)" />

--- a/src/NerdBank.GitVersioning/Nerdbank.GitVersioning.csproj
+++ b/src/NerdBank.GitVersioning/Nerdbank.GitVersioning.csproj
@@ -11,6 +11,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="DotNetMDDocs" PrivateAssets="all" Condition=" '$(GenerateMarkdownApiDocs)' == 'true' " />
+    <PackageReference Include="editorconfig" />
     <PackageReference Include="LibGit2Sharp" PrivateAssets="none" />
     <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" />
     <PackageReference Include="Microsoft.Windows.CsWin32" PrivateAssets="all" />

--- a/src/NerdBank.GitVersioning/VersionFile.cs
+++ b/src/NerdBank.GitVersioning/VersionFile.cs
@@ -3,6 +3,7 @@
 
 #nullable enable
 
+using EditorConfig.Core;
 using Newtonsoft.Json;
 using Validation;
 
@@ -110,6 +111,17 @@ public abstract class VersionFile
         string jsonContent = JsonConvert.SerializeObject(
             version,
             VersionOptions.GetJsonSettings(version.Inherit, includeSchemaProperty, repoRelativeProjectDirectory));
+        FileConfiguration editorConfig = new EditorConfigParser().Parse(versionJsonPath);
+        if (editorConfig.InsertFinalNewline is true)
+        {
+            jsonContent += editorConfig.EndOfLine switch
+            {
+                EndOfLine.CR => "\r",
+                EndOfLine.CRLF => "\r\n",
+                _ => "\n",
+            };
+        }
+
         File.WriteAllText(versionJsonPath, jsonContent);
         return versionJsonPath;
     }

--- a/test/Nerdbank.GitVersioning.Tests/VersionFileTests.cs
+++ b/test/Nerdbank.GitVersioning.Tests/VersionFileTests.cs
@@ -132,6 +132,26 @@ public abstract class VersionFileTests : RepoTestBase
     }
 
     [Theory]
+    [InlineData("true", "lf", "\n")]
+    [InlineData("true", "crlf", "\r\n")]
+    [InlineData("false", "lf", "")]
+    public void SetVersion_RespectsEditorConfigFinalNewline(string insertFinalNewline, string endOfLine, string expectedFinalNewline)
+    {
+        File.WriteAllText(
+            Path.Combine(this.RepoPath, ".editorconfig"),
+            $"root = true{Environment.NewLine}[*.json]{Environment.NewLine}insert_final_newline = {insertFinalNewline}{Environment.NewLine}end_of_line = {endOfLine}{Environment.NewLine}");
+
+        string pathWritten = this.Context.VersionFile.SetVersion(this.RepoPath, new Version(2, 3));
+        string actualFileContent = File.ReadAllText(pathWritten);
+        string actualFinalNewline = actualFileContent.EndsWith("\r\n", StringComparison.Ordinal) ? "\r\n"
+            : actualFileContent.EndsWith("\n", StringComparison.Ordinal) ? "\n"
+            : actualFileContent.EndsWith("\r", StringComparison.Ordinal) ? "\r"
+            : string.Empty;
+
+        Assert.Equal(expectedFinalNewline, actualFinalNewline);
+    }
+
+    [Theory]
     [InlineData("2.3", null, VersionOptions.VersionPrecision.Minor, 0, false, @"{""version"":""2.3""}")]
     [InlineData("2.3", null, VersionOptions.VersionPrecision.Minor, null, true, @"{""version"":""2.3"",""assemblyVersion"":{""precision"":""minor""},""inherit"":true}")]
     [InlineData("2.3", "2.2", VersionOptions.VersionPrecision.Minor, 0, false, @"{""version"":""2.3"",""assemblyVersion"":""2.2""}")]


### PR DESCRIPTION
`nbgv set-version` currently writes `version.json` without regard for the repository's EditorConfig settings, which can immediately leave the generated file out of compliance with the project style.

Use EditorConfig Core to resolve settings for the target `version.json`. When `insert_final_newline` is enabled, append the configured `end_of_line` sequence; otherwise preserve the existing no-final-newline behavior. Tests cover LF, CRLF, and disabled final-newline configurations.

Fixes dotnet/Nerdbank.GitVersioning#419