### PR TITLE
Fix version height parity for filtered paths

### DIFF
--- a/src/NerdBank.GitVersioning/LibGit2/LibGit2GitExtensions.cs
+++ b/src/NerdBank.GitVersioning/LibGit2/LibGit2GitExtensions.cs
@@ -473,33 +473,27 @@ public static class LibGit2GitExtensions
             VersionOptions? versionOptions = tracker.GetVersion(commit);
             IReadOnlyList<FilterPath>? pathFilters = versionOptions?.PathFilters;
 
-            var includePaths =
-                pathFilters
-                    ?.Where(filter => !filter.IsExclude)
-                    .Select(filter => filter.RepoRelativePath)
-                    .ToList();
-
-            var excludePaths = pathFilters?.Where(filter => filter.IsExclude).ToList();
-
             bool ignoreCase = commit.GetRepository().Config.Get<bool>("core.ignorecase")?.Value ?? false;
             bool ContainsRelevantChanges(IEnumerable<TreeEntryChanges> changes) =>
-                excludePaths?.Count == 0
-                    ? changes.Any()
-                    //// If there is a single change that isn't excluded,
-                    //// then this commit is relevant.
-                    : changes.Any(change => !excludePaths!.Any(exclude => exclude.Excludes(change.Path, ignoreCase)));
+                changes.Any(change =>
+                    (!pathFilters!.Any(filter => filter.IsInclude) || pathFilters.Any(filter => filter.Includes(change.Path, ignoreCase)))
+                    && !pathFilters.Any(filter => filter.Excludes(change.Path, ignoreCase)));
 
             int height = 1;
 
-            if (includePaths is not null)
+            if (pathFilters is not null)
             {
-                // If there are no include paths, or any of the include
-                // paths refer to the root of the repository, then do not
-                // filter the diff at all.
+                List<FilterPath> includeFilters = pathFilters.Where(filter => filter.IsInclude).ToList();
                 List<string>? diffInclude =
-                    includePaths.Count == 0 || pathFilters!.Any(filter => filter.IsRoot)
-                        ? null
-                        : includePaths;
+                    !ignoreCase
+                    && includeFilters.Count > 0
+                    && !includeFilters.Any(filter => filter.IsRoot)
+                    && !includeFilters.Any(filter =>
+                        filter.RepoRelativePath.IndexOf('*') >= 0
+                        || filter.RepoRelativePath.IndexOf('?') >= 0
+                        || filter.RepoRelativePath.IndexOf('[') >= 0)
+                        ? includeFilters.Select(filter => filter.RepoRelativePath).ToList()
+                        : null;
 
                 // If the diff between this commit and any of its parents
                 // touches a path that we care about, bump the height.

--- a/src/NerdBank.GitVersioning/Managed/GitExtensions.cs
+++ b/src/NerdBank.GitVersioning/Managed/GitExtensions.cs
@@ -135,16 +135,6 @@ internal static class GitExtensions
             VersionOptions? versionOptions = tracker.GetVersion(commit);
             IReadOnlyList<FilterPath>? pathFilters = versionOptions?.PathFilters;
 
-            var includePaths =
-                pathFilters
-                    ?.Where(filter => !filter.IsExclude)
-                    .Select(filter => filter.RepoRelativePath)
-                    .ToList();
-
-            var excludePaths = pathFilters?.Where(filter => filter.IsExclude).ToList();
-
-            bool ignoreCase = repository.IgnoreCase;
-
             int height = 1;
 
             if (pathFilters is not null)
@@ -218,7 +208,8 @@ internal static class GitExtensions
             // if the Sha does not match, it was modified.
             if (parent is null ||
                 !parent.Children.TryGetValue(child.Key, out parentEntry) ||
-                parentEntry.Sha != child.Value.Sha)
+                parentEntry.Sha != child.Value.Sha ||
+                parentEntry.Mode != child.Value.Mode)
             {
                 // Determine whether the change was relevant.
                 string? fullPath = $"{relativePath}{entry.Name}";
@@ -236,7 +227,7 @@ internal static class GitExtensions
                     isRelevant = IsRelevantCommit(
                         repository,
                         repository.GetTree(entry.Sha),
-                        parentEntry is null ? GitTree.Empty : repository.GetTree(parentEntry.Sha),
+                        parentEntry is null || parentEntry.IsFile ? GitTree.Empty : repository.GetTree(parentEntry.Sha),
                         $"{fullPath}/",
                         filters);
                 }
@@ -248,7 +239,7 @@ internal static class GitExtensions
                 }
             }
 
-            if (parentEntry is not null)
+            if (parentEntry is not null && parentEntry.IsFile == entry.IsFile)
             {
                 Assumes.NotNull(parent);
                 parent.Children.Remove(child.Key);

--- a/src/NerdBank.GitVersioning/Managed/GitExtensions.cs
+++ b/src/NerdBank.GitVersioning/Managed/GitExtensions.cs
@@ -260,14 +260,20 @@ internal static class GitExtensions
         {
             foreach (KeyValuePair<string, GitTreeEntry> child in parent.Children)
             {
-                // Determine whether the change was relevant.
-                string? fullPath = Path.Combine(relativePath, child.Key);
+                string fullPath = $"{relativePath}{child.Key}";
+                if (!child.Value.IsFile)
+                {
+                    if (IsRelevantCommit(repository, GitTree.Empty, repository.GetTree(child.Value.Sha), $"{fullPath}/", filters))
+                    {
+                        return true;
+                    }
 
-                bool isRelevant =
-                    filters.Any(f => f.Includes(fullPath, repository.IgnoreCase))
-                    && !filters.Any(f => f.Excludes(fullPath, repository.IgnoreCase));
+                    continue;
+                }
 
-                if (isRelevant)
+                // With no include filters, every path is included unless explicitly excluded.
+                if ((!filters.Any(f => f.IsInclude) || filters.Any(f => f.Includes(fullPath, repository.IgnoreCase)))
+                    && !filters.Any(f => f.Excludes(fullPath, repository.IgnoreCase)))
                 {
                     return true;
                 }

--- a/src/NerdBank.GitVersioning/ManagedGit/GitTreeEntry.cs
+++ b/src/NerdBank.GitVersioning/ManagedGit/GitTreeEntry.cs
@@ -23,10 +23,23 @@ public class GitTreeEntry
     /// The Git object Id of the blob or tree of the current entry.
     /// </param>
     public GitTreeEntry(string name, bool isFile, GitObjectId sha)
+        : this(name, isFile, sha, mode: 0)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GitTreeEntry"/> class.
+    /// </summary>
+    /// <param name="name">The name of the entry.</param>
+    /// <param name="isFile">A value indicating whether the entry is a file.</param>
+    /// <param name="sha">The Git object ID of the blob or tree.</param>
+    /// <param name="mode">The Git tree entry mode.</param>
+    internal GitTreeEntry(string name, bool isFile, GitObjectId sha, int mode)
     {
         this.Name = name;
         this.IsFile = isFile;
         this.Sha = sha;
+        this.Mode = mode;
     }
 
     /// <summary>
@@ -43,6 +56,11 @@ public class GitTreeEntry
     /// Gets the Git object Id of the blob or tree of the current entry.
     /// </summary>
     public GitObjectId Sha { get; }
+
+    /// <summary>
+    /// Gets the Git tree entry mode.
+    /// </summary>
+    internal int Mode { get; }
 
     /// <inheritdoc/>
     public override string ToString()

--- a/src/NerdBank.GitVersioning/ManagedGit/GitTreeReader.cs
+++ b/src/NerdBank.GitVersioning/ManagedGit/GitTreeReader.cs
@@ -34,6 +34,11 @@ internal static class GitTreeReader
                 int fileNameEnds = contents.IndexOf((byte)0);
                 bool isFile = contents[0] == (byte)'1';
                 int modeLength = isFile ? 7 : 6;
+                int mode = 0;
+                for (int i = 0; i < modeLength - 1; i++)
+                {
+                    mode = (mode * 8) + (contents[i] - '0');
+                }
 
                 Span<byte> currentName = contents.Slice(modeLength, fileNameEnds - modeLength);
                 var currentObjectId = GitObjectId.Parse(contents.Slice(fileNameEnds + 1, 20));
@@ -42,7 +47,7 @@ internal static class GitTreeReader
 
                 value.Children.Add(
                     name,
-                    new GitTreeEntry(name, isFile, currentObjectId));
+                    new GitTreeEntry(name, isFile, currentObjectId, mode));
 
                 contents = contents.Slice(fileNameEnds + 1 + 20);
             }

--- a/test/Nerdbank.GitVersioning.Tests/VersionOracleTests.cs
+++ b/test/Nerdbank.GitVersioning.Tests/VersionOracleTests.cs
@@ -977,6 +977,27 @@ public abstract class VersionOracleTests : RepoTestBase
         Assert.Equal(2, this.GetVersionHeight());
     }
 
+    [Fact]
+    public void GetVersionHeight_DeletingIncludedFileWithOnlyExcludeFilter()
+    {
+        this.InitializeSourceControl();
+
+        var versionData = VersionOptions.FromVersion(new Version("1.2"));
+        versionData.PathFilters = new[] { new FilterPath(":!README.md", ".") };
+        this.WriteVersionFile(versionData);
+
+        string includedFilePath = Path.Combine(this.RepoPath, "included.txt");
+        File.WriteAllText(includedFilePath, "hello");
+        Commands.Stage(this.LibGit2Repository, includedFilePath);
+        this.LibGit2Repository.Commit("Add included file", this.Signer, this.Signer);
+        Assert.Equal(2, this.GetVersionHeight());
+
+        File.Delete(includedFilePath);
+        Commands.Stage(this.LibGit2Repository, includedFilePath);
+        this.LibGit2Repository.Commit("Delete included file", this.Signer, this.Signer);
+        Assert.Equal(3, this.GetVersionHeight());
+    }
+
     [Theory]
     [InlineData(":^/excluded-dir")]
     [InlineData(":^../excluded-dir")]

--- a/test/Nerdbank.GitVersioning.Tests/VersionOracleTests.cs
+++ b/test/Nerdbank.GitVersioning.Tests/VersionOracleTests.cs
@@ -975,6 +975,11 @@ public abstract class VersionOracleTests : RepoTestBase
         Commands.Stage(this.LibGit2Repository, fileInExcludedDirPath);
         this.LibGit2Repository.Commit("Add file to excluded dir", this.Signer, this.Signer);
         Assert.Equal(2, this.GetVersionHeight());
+
+        Directory.Delete(Path.GetDirectoryName(fileInExcludedDirPath), recursive: true);
+        Commands.Stage(this.LibGit2Repository, Path.GetDirectoryName(fileInExcludedDirPath));
+        this.LibGit2Repository.Commit("Delete excluded dir", this.Signer, this.Signer);
+        Assert.Equal(2, this.GetVersionHeight());
     }
 
     [Fact]
@@ -996,6 +1001,111 @@ public abstract class VersionOracleTests : RepoTestBase
         Commands.Stage(this.LibGit2Repository, includedFilePath);
         this.LibGit2Repository.Commit("Delete included file", this.Signer, this.Signer);
         Assert.Equal(3, this.GetVersionHeight());
+    }
+
+    [Fact]
+    public void GetVersionHeight_ChangingIncludedFileMode()
+    {
+        this.InitializeSourceControl();
+
+        var versionData = VersionOptions.FromVersion(new Version("1.2"));
+        versionData.PathFilters = new[] { new FilterPath("included.txt", ".") };
+        this.WriteVersionFile(versionData);
+
+        string includedFilePath = Path.Combine(this.RepoPath, "included.txt");
+        File.WriteAllText(includedFilePath, "hello");
+        Commands.Stage(this.LibGit2Repository, includedFilePath);
+        this.LibGit2Repository.Commit("Add included file", this.Signer, this.Signer);
+        Assert.Equal(1, this.GetVersionHeight());
+
+        var includedBlob = (Blob)this.LibGit2Repository.Head.Tip["included.txt"].Target;
+        this.LibGit2Repository.Index.Add(includedBlob, "included.txt", Mode.ExecutableFile);
+        this.LibGit2Repository.Index.Write();
+        this.LibGit2Repository.Commit("Make included file executable", this.Signer, this.Signer);
+        Assert.Equal(2, this.GetVersionHeight());
+    }
+
+    [Fact]
+    public void GetVersionHeight_IncludeFilterTreatsMetacharactersLiterally()
+    {
+        this.InitializeSourceControl();
+
+        var versionData = VersionOptions.FromVersion(new Version("1.2"));
+        versionData.PathFilters = new[] { new FilterPath("dir/*.txt", ".") };
+        this.WriteVersionFile(versionData);
+
+        string directoryPath = Path.Combine(this.RepoPath, "dir");
+        Directory.CreateDirectory(directoryPath);
+        string filePath = Path.Combine(directoryPath, "value.txt");
+        File.WriteAllText(filePath, "hello");
+        Commands.Stage(this.LibGit2Repository, filePath);
+        this.LibGit2Repository.Commit("Add file outside literal filter", this.Signer, this.Signer);
+        Assert.Equal(0, this.GetVersionHeight());
+    }
+
+    [Fact]
+    public void GetVersionHeight_IncludeFilterHonorsIgnoreCase()
+    {
+        this.InitializeSourceControl();
+        this.LibGit2Repository.Config.Set("core.ignorecase", true, ConfigurationLevel.Local);
+
+        var versionData = VersionOptions.FromVersion(new Version("1.2"));
+        versionData.PathFilters = new[] { new FilterPath("SRC/INCLUDED.TXT", ".") };
+        this.WriteVersionFile(versionData);
+
+        string directoryPath = Path.Combine(this.RepoPath, "src");
+        Directory.CreateDirectory(directoryPath);
+        string filePath = Path.Combine(directoryPath, "included.txt");
+        File.WriteAllText(filePath, "hello");
+        Commands.Stage(this.LibGit2Repository, filePath);
+        this.LibGit2Repository.Commit("Add included file with different casing", this.Signer, this.Signer);
+        Assert.Equal(1, this.GetVersionHeight());
+    }
+
+    [Fact]
+    public void GetVersionHeight_ReplacingFileWithIncludedDirectory()
+    {
+        this.InitializeSourceControl();
+
+        var versionData = VersionOptions.FromVersion(new Version("1.2"));
+        versionData.PathFilters = new[] { new FilterPath("target/included.txt", ".") };
+        this.WriteVersionFile(versionData);
+
+        string targetPath = Path.Combine(this.RepoPath, "target");
+        File.WriteAllText(targetPath, "not included");
+        Commands.Stage(this.LibGit2Repository, targetPath);
+        this.LibGit2Repository.Commit("Add file outside filter", this.Signer, this.Signer);
+        Assert.Equal(0, this.GetVersionHeight());
+
+        File.Delete(targetPath);
+        Directory.CreateDirectory(targetPath);
+        File.WriteAllText(Path.Combine(targetPath, "included.txt"), "included");
+        Commands.Stage(this.LibGit2Repository, targetPath);
+        this.LibGit2Repository.Commit("Replace file with included directory", this.Signer, this.Signer);
+        Assert.Equal(1, this.GetVersionHeight());
+    }
+
+    [Fact]
+    public void GetVersionHeight_ReplacingIncludedDirectoryWithFile()
+    {
+        this.InitializeSourceControl();
+
+        var versionData = VersionOptions.FromVersion(new Version("1.2"));
+        versionData.PathFilters = new[] { new FilterPath("target/included.txt", ".") };
+        this.WriteVersionFile(versionData);
+
+        string targetPath = Path.Combine(this.RepoPath, "target");
+        Directory.CreateDirectory(targetPath);
+        File.WriteAllText(Path.Combine(targetPath, "included.txt"), "included");
+        Commands.Stage(this.LibGit2Repository, targetPath);
+        this.LibGit2Repository.Commit("Add included directory", this.Signer, this.Signer);
+        Assert.Equal(1, this.GetVersionHeight());
+
+        Directory.Delete(targetPath, recursive: true);
+        File.WriteAllText(targetPath, "not included");
+        Commands.Stage(this.LibGit2Repository, targetPath);
+        this.LibGit2Repository.Commit("Replace included directory with file", this.Signer, this.Signer);
+        Assert.Equal(2, this.GetVersionHeight());
     }
 
     [Theory]


### PR DESCRIPTION
## Summary

- count deletions of included files when `pathFilters` contains only exclusions
- align managed and LibGit2 height calculations for mode changes, file/directory replacements, literal path-filter metacharacters, and case-insensitive repositories
- add regression coverage that runs against both Git engines

Fixes #1488

## Tests

- `dotnet test --project test\Nerdbank.GitVersioning.Tests\Nerdbank.GitVersioning.Tests.csproj --framework net10.0 -- --filter-class VersionOracleManagedTests --filter-class VersionOracleLibGit2Tests --filter-not-trait "TestCategory=FailsInCloudTest"`
