### PR TITLE
Dispose test Git contexts deterministically

### DIFF
--- a/test/Nerdbank.GitVersioning.Tests/GitContextTests.cs
+++ b/test/Nerdbank.GitVersioning.Tests/GitContextTests.cs
@@ -179,7 +179,7 @@ public abstract class GitContextTests : RepoTestBase
 
             // The managed git context always assumes read-only access. It won't detect a new Git pack file being
             // created on the fly, so we have to re-initialize.
-            this.Context = this.CreateGitContext(this.RepoPath, null);
+            this.RecreateContext();
         }
 
         Assert.True(this.Context.TrySelectCommit(this.Context.GitCommitId.Substring(0, oddLength ? 11 : 12)));
@@ -268,10 +268,10 @@ public abstract class GitContextTests : RepoTestBase
     public void GetVersion_PackedHead()
     {
         using TestUtilities.ExpandedRepo expandedRepo = TestUtilities.ExtractRepoArchive("PackedHeadRef");
-        this.Context = this.CreateGitContext(Path.Combine(expandedRepo.RepoPath));
-        var oracle = new VersionOracle(this.Context);
+        using GitContext context = this.CreateGitContext(Path.Combine(expandedRepo.RepoPath));
+        var oracle = new VersionOracle(context);
         Assert.Equal("1.0.1", oracle.SimpleVersion.ToString());
-        this.Context.TrySelectCommit("HEAD");
+        context.TrySelectCommit("HEAD");
         Assert.Equal("1.0.1", oracle.SimpleVersion.ToString());
     }
 
@@ -279,8 +279,8 @@ public abstract class GitContextTests : RepoTestBase
     public void HeadCanonicalName_PackedHead()
     {
         using TestUtilities.ExpandedRepo expandedRepo = TestUtilities.ExtractRepoArchive("PackedHeadRef");
-        this.Context = this.CreateGitContext(Path.Combine(expandedRepo.RepoPath));
-        Assert.Equal("refs/heads/main", this.Context.HeadCanonicalName);
+        using GitContext context = this.CreateGitContext(Path.Combine(expandedRepo.RepoPath));
+        Assert.Equal("refs/heads/main", context.HeadCanonicalName);
     }
 
     [Fact]
@@ -594,7 +594,6 @@ public abstract class GitContextTests : RepoTestBase
 
     private void RecreateContext()
     {
-        this.Context.Dispose();
-        this.Context = this.CreateGitContext(this.RepoPath);
+        this.ReplaceContext(this.CreateGitContext(this.RepoPath));
     }
 }

--- a/test/Nerdbank.GitVersioning.Tests/RepoTestBase.cs
+++ b/test/Nerdbank.GitVersioning.Tests/RepoTestBase.cs
@@ -45,6 +45,12 @@ public abstract partial class RepoTestBase : IDisposable
 
     protected abstract GitContext CreateGitContext(string path, string? committish = null);
 
+    protected void ReplaceContext(GitContext context)
+    {
+        this.Context?.Dispose();
+        this.Context = context;
+    }
+
     protected void SetContextToHead() => Assumes.True(this.Context?.TrySelectCommit("HEAD") ?? false);
 
     protected VersionOptions? GetVersionOptions(string? path = null, string? committish = null)

--- a/test/Nerdbank.GitVersioning.Tests/VersionOracleTests.cs
+++ b/test/Nerdbank.GitVersioning.Tests/VersionOracleTests.cs
@@ -53,7 +53,7 @@ public abstract class VersionOracleTests : RepoTestBase
     public void NotRepo()
     {
         // Seems safe to assume a temporary path is not a Git directory.
-        GitContext context = this.CreateGitContext(Path.GetTempPath());
+        using GitContext context = this.CreateGitContext(Path.GetTempPath());
         var oracle = new VersionOracle(context);
         Assert.Equal(0, oracle.VersionHeight);
     }
@@ -75,13 +75,13 @@ public abstract class VersionOracleTests : RepoTestBase
     {
         using (TestUtilities.ExpandedRepo expandedRepo = TestUtilities.ExtractRepoArchive("submodules"))
         {
-            this.Context = this.CreateGitContext(Path.Combine(expandedRepo.RepoPath, "a"));
-            var oracleA = new VersionOracle(this.Context);
+            using GitContext contextA = this.CreateGitContext(Path.Combine(expandedRepo.RepoPath, "a"));
+            var oracleA = new VersionOracle(contextA);
             Assert.Equal("1.3.1", oracleA.SimpleVersion.ToString());
             Assert.Equal("e238b03e75", oracleA.GitCommitIdShort);
 
-            this.Context = this.CreateGitContext(Path.Combine(expandedRepo.RepoPath, "b", "projB"));
-            var oracleB = new VersionOracle(this.Context);
+            using GitContext contextB = this.CreateGitContext(Path.Combine(expandedRepo.RepoPath, "b", "projB"));
+            var oracleB = new VersionOracle(contextB);
             Assert.Equal("2.5.2", oracleB.SimpleVersion.ToString());
             Assert.Equal("3ea7f010c3", oracleB.GitCommitIdShort);
         }
@@ -851,7 +851,7 @@ public abstract class VersionOracleTests : RepoTestBase
         // Workaround for https://github.com/libgit2/libgit2sharp/issues/2037
         Commands.Checkout(worktree.WorktreeRepository, "HEAD", new CheckoutOptions { CheckoutModifiers = CheckoutModifiers.Force });
 
-        GitContext context = this.CreateGitContext(workTreePath);
+        using GitContext context = this.CreateGitContext(workTreePath);
         var oracleWorkTree = new VersionOracle(context);
         Assert.Equal(oracleOriginal.Version, oracleWorkTree.Version);
 
@@ -1668,7 +1668,7 @@ public abstract class VersionOracleTests : RepoTestBase
         this.LibGit2Repository.ApplyTag("mytag");
 
         // Refresh our context before asking again.
-        this.Context = this.CreateGitContext(this.RepoPath);
+        this.ReplaceContext(this.CreateGitContext(this.RepoPath));
         VersionOracle oracle2 = new(this.Context);
 
         // Assert that we see the tag.
@@ -1678,7 +1678,7 @@ public abstract class VersionOracleTests : RepoTestBase
         this.AddCommits(1);
 
         // Refresh our context before asking again.
-        this.Context = this.CreateGitContext(this.RepoPath);
+        this.ReplaceContext(this.CreateGitContext(this.RepoPath));
         VersionOracle oracle3 = new(this.Context);
 
         // Assert that HEAD is not pointing to the tag.
@@ -1700,7 +1700,7 @@ public abstract class VersionOracleTests : RepoTestBase
         this.LibGit2Repository.ApplyTag("mytag", this.Signer, "my tag");
 
         // Refresh our context before asking again.
-        this.Context = this.CreateGitContext(this.RepoPath);
+        this.ReplaceContext(this.CreateGitContext(this.RepoPath));
         VersionOracle oracle2 = new(this.Context);
 
         // Assert that we see the tag.
@@ -1710,7 +1710,7 @@ public abstract class VersionOracleTests : RepoTestBase
         this.AddCommits(1);
 
         // Refresh our context before asking again.
-        this.Context = this.CreateGitContext(this.RepoPath);
+        this.ReplaceContext(this.CreateGitContext(this.RepoPath));
         VersionOracle oracle3 = new(this.Context);
 
         // Assert that HEAD is not pointing to the tag.


### PR DESCRIPTION
## Summary

Dispose test `GitContext` instances deterministically when replacing fixture contexts or using temporary repositories.

This prevents LibGit2Sharp handles from surviving repository cleanup and being finalized unpredictably, which caused the Linux/net10 test process to terminate with an access violation in `GitContext.Dispose`.

## Testing

- `dotnet test --project test\Nerdbank.GitVersioning.Tests\Nerdbank.GitVersioning.Tests.csproj --no-build -c Release --framework net10.0 -- --filter-not-trait "TestCategory=FailsInCloudTest"`
