### PR TITLE
Preserve LibGit2 lifetimes and serialize tests

### DIFF
--- a/src/NerdBank.GitVersioning/LibGit2/LibGit2GitExtensions.cs
+++ b/src/NerdBank.GitVersioning/LibGit2/LibGit2GitExtensions.cs
@@ -110,7 +110,7 @@ public static class LibGit2GitExtensions
                                                where !IsVersionHeightMismatch(version, commitVersionOptions, commit, tracker)
                                                select commit;
 
-        return possibleCommits;
+        return possibleCommits.ToList();
     }
 
     /// <summary>

--- a/src/NerdBank.GitVersioning/VersionOracle.cs
+++ b/src/NerdBank.GitVersioning/VersionOracle.cs
@@ -21,9 +21,13 @@ public class VersionOracle
 
     private const bool UseLibGit2 = false;
 
-    private readonly GitContext context;
-
     private readonly string? gitCommitId;
+
+    private readonly DateTimeOffset? gitCommitDate;
+
+    private readonly DateTimeOffset? gitCommitAuthorDate;
+
+    private readonly IReadOnlyCollection<string>? tags;
 
     private readonly bool isWorkingTreeDirty;
 
@@ -46,7 +50,9 @@ public class VersionOracle
     /// <param name="overrideVersionHeightOffset">An optional value to override the version height offset.</param>
     public VersionOracle(GitContext context, ICloudBuild? cloudBuild = null, int? overrideVersionHeightOffset = null)
     {
-        this.context = context;
+        this.gitCommitDate = context.GitCommitDate;
+        this.gitCommitAuthorDate = context.GitCommitAuthorDate;
+        this.tags = context.HeadTags?.ToArray();
         string? rawGitCommitId = context.GitCommitId ?? cloudBuild?.GitCommitId;
         this.gitCommitId = rawGitCommitId;
         this.CommittedVersion = context.VersionFile.GetVersion();
@@ -116,7 +122,7 @@ public class VersionOracle
 
             // Get it from the git repository if there is a repository present and it is enabled.
             string gitCommitIdShort = gitCommitIdShortAutoMinimum > 0
-                ? this.context.GetShortUniqueCommitId(gitCommitIdShortAutoMinimum)
+                ? context.GetShortUniqueCommitId(gitCommitIdShortAutoMinimum)
                 : rawGitCommitId!.Substring(0, gitCommitIdShortFixedLength);
             this.GitCommitIdShort = this.isWorkingTreeDirty ? gitCommitIdShort + "-dirty" : gitCommitIdShort;
         }
@@ -126,7 +132,7 @@ public class VersionOracle
             int gitCommitIdShortFixedLength = this.VersionOptions?.GitCommitIdShortFixedLength ?? VersionOptions.DefaultGitCommitIdShortFixedLength;
             int gitCommitIdShortAutoMinimum = this.VersionOptions?.GitCommitIdShortAutoMinimum ?? 0;
             this.versionGitCommitIdShort = gitCommitIdShortAutoMinimum > 0
-                ? this.context.GetShortUniqueCommitId(this.versionGitCommitId!, gitCommitIdShortAutoMinimum)
+                ? context.GetShortUniqueCommitId(this.versionGitCommitId!, gitCommitIdShortAutoMinimum)
                 : this.versionGitCommitId!.Substring(0, gitCommitIdShortFixedLength);
         }
 
@@ -314,12 +320,12 @@ public class VersionOracle
     /// <summary>
     /// Gets the Git revision control commit date for HEAD (the current source code version).
     /// </summary>
-    public DateTimeOffset? GitCommitDate => this.context.GitCommitDate;
+    public DateTimeOffset? GitCommitDate => this.gitCommitDate;
 
     /// <summary>
     /// Gets the Git revision control commit author date for HEAD (the current source code version).
     /// </summary>
-    public DateTimeOffset? GitCommitAuthorDate => this.context.GitCommitAuthorDate;
+    public DateTimeOffset? GitCommitAuthorDate => this.gitCommitAuthorDate;
 
     /// <summary>
     /// Gets or sets the number of commits in the longest single path between
@@ -353,7 +359,7 @@ public class VersionOracle
     /// Gets a collection of the tags that reference HEAD.
     /// </summary>
     [Ignore]
-    public IReadOnlyCollection<string>? Tags => this.context.HeadTags;
+    public IReadOnlyCollection<string>? Tags => this.tags;
 
     /// <summary>
     /// Gets or sets the version for this project, with up to 4 components.

--- a/test/Nerdbank.GitVersioning.Tests/LibGit2GitExtensionsTests.cs
+++ b/test/Nerdbank.GitVersioning.Tests/LibGit2GitExtensionsTests.cs
@@ -307,6 +307,22 @@ public class LibGit2GitExtensionsTests : RepoTestBase
     }
 
     [Fact]
+    public void GetCommitsFromVersion_MaterializesBeforeContextIsDisposed()
+    {
+        this.InitializeSourceControl();
+        Commit commit = this.WriteVersionFile(new VersionOptions { Version = SemanticVersion.Parse("1.2") });
+        Version version = new VersionOracle(this.Context).Version;
+        IEnumerable<Commit> matchingCommits;
+
+        using (LibGit2Context context = LibGit2Context.Create(this.RepoPath))
+        {
+            matchingCommits = LibGit2GitExtensions.GetCommitsFromVersion(context, version);
+        }
+
+        Assert.Single(matchingCommits, candidate => candidate.Sha == commit.Sha);
+    }
+
+    [Fact]
     public void GetIdAsVersion_Roundtrip_WithSubdirectoryVersionFiles()
     {
         var rootVersionExpected = VersionOptions.FromVersion(new Version(1, 0));

--- a/test/Nerdbank.GitVersioning.Tests/VersionOracleTests.cs
+++ b/test/Nerdbank.GitVersioning.Tests/VersionOracleTests.cs
@@ -59,6 +59,22 @@ public abstract class VersionOracleTests : RepoTestBase
     }
 
     [Fact]
+    public void GetVersionOracle_CapturesContextDataBeforeDisposal()
+    {
+        this.WriteVersionFile();
+        this.InitializeSourceControl();
+        this.LibGit2Repository.ApplyTag("test");
+
+        VersionOracle oracle = this.GetVersionOracle();
+
+        Assert.Equal(this.LibGit2Repository.Head.Tip.Committer.When, oracle.GitCommitDate);
+        Assert.Equal(this.LibGit2Repository.Head.Tip.Author.When, oracle.GitCommitAuthorDate);
+        Assert.Equal("refs/tags/test", Assert.Single(oracle.Tags));
+        Assert.Contains("NBGV_GitCommitDate", oracle.CloudBuildAllVars.Keys);
+        Assert.Contains("NBGV_GitCommitAuthorDate", oracle.CloudBuildAllVars.Keys);
+    }
+
+    [Fact]
     public void EmptyRepoWithCloudCommitNotInRepository()
     {
         this.InitializeSourceControl(withInitialCommit: false);

--- a/test/Nerdbank.GitVersioning.Tests/xunit.runner.json
+++ b/test/Nerdbank.GitVersioning.Tests/xunit.runner.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "parallelizeTestCollections": false,
   "shadowCopy": false
 }


### PR DESCRIPTION
## Summary

Preserve LibGit2Sharp object lifetimes by materializing commit queries before returning them and snapshotting `VersionOracle` context data at construction.

This eliminates deferred native access after a `GitContext` has been disposed, a repository-local source of Linux/net10 access violations.

Serializes this test assembly's collections as temporary containment for a remaining access violation in LibGit2Sharp's live `Commit.Parents` path. The upstream failure is tracked in libgit2/libgit2sharp#2192.

## Testing

- `dotnet test --project test\Nerdbank.GitVersioning.Tests\Nerdbank.GitVersioning.Tests.csproj -c Release --framework net10.0 -- --filter-not-trait "TestCategory=FailsInCloudTest"`
